### PR TITLE
print program trace for debugging

### DIFF
--- a/src/RaceDetect.cpp
+++ b/src/RaceDetect.cpp
@@ -66,5 +66,7 @@ Report race::detectRaces(llvm::Module *module) {
     }
   }
 
+  llvm::outs() << program << "\n";
+
   return reporter.getReport();
 }

--- a/src/Trace/Event.cpp
+++ b/src/Trace/Event.cpp
@@ -13,6 +13,37 @@ limitations under the License.
 
 using namespace race;
 
+llvm::raw_ostream &race::operator<<(llvm::raw_ostream &os, const Event::Type &type) {
+  switch (type) {
+    case Event::Type::Read:
+      os << "Read";
+      break;
+    case Event::Type::Write:
+      os << "Write";
+      break;
+    case Event::Type::Fork:
+      os << "Fork";
+      break;
+    case Event::Type::Join:
+      os << "Join";
+      break;
+    case Event::Type::Lock:
+      os << "Lock";
+      break;
+    case Event::Type::Unlock:
+      os << "Unlock";
+      break;
+    case Event::Type::Call:
+      os << "Call";
+      break;
+    case Event::Type::CallEnd:
+      os << "EndCall";
+      break;
+  }
+
+  return os;
+}
+
 void ReadEvent::print(llvm::raw_ostream &os) const {
   // TODO
   os << "Event: READ\n";

--- a/src/Trace/Event.h
+++ b/src/Trace/Event.h
@@ -44,6 +44,8 @@ class Event {
   explicit Event(Type type) : type(type) {}
 };
 
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Event::Type &type);
+
 class MemAccessEvent : public Event {
  protected:
   using Event::Event;

--- a/src/Trace/ProgramTrace.cpp
+++ b/src/Trace/ProgramTrace.cpp
@@ -51,3 +51,23 @@ ProgramTrace::ProgramTrace(llvm::Module *module, llvm::StringRef entryName) {
     }
   }
 }
+
+llvm::raw_ostream &race::operator<<(llvm::raw_ostream &os, const ProgramTrace &trace) {
+  os << "===== Program Trace =====\n";
+  auto const &threads = trace.getThreads();
+  for (auto const &thread : threads) {
+    os << "----T" << thread->id;
+    if (thread->spawnEvent.has_value()) {
+      auto const &spawn = thread->spawnEvent.value();
+      os << "  (Spawned by T" << spawn->getThread().id << ":" << spawn->getID() << ")";
+    }
+    os << "\n";
+    auto const &events = thread->getEvents();
+    for (auto const &event : events) {
+      os << event->getID() << " " << event->type << " " << *event->getInst() << "\n";
+    }
+  }
+
+  os << "========================\n";
+  return os;
+}

--- a/src/Trace/ProgramTrace.h
+++ b/src/Trace/ProgramTrace.h
@@ -36,4 +36,6 @@ class ProgramTrace {
   ProgramTrace &operator=(ProgramTrace &&) = delete;
 };
 
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const ProgramTrace &trace);
+
 }  // namespace race

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,7 +50,7 @@ int main(int argc, char** argv) {
   // TODO: should output to json or something and let something else handle displaying results
   llvm::outs() << "==== Races ====\n";
   for (auto const& race : report) {
-    llvm::outs() << race.first << " " << race.second << "\n";
+    llvm::outs() << race << "\n";
   }
   llvm::outs() << "Total Races Detected: " << report.size() << "\n";
 


### PR DESCRIPTION
add an `operator<<` for `ProgramTrace` that outputs some info to help debug.

The output looks like
```
===== Program Trace =====
----T0
0 Write   store i32 0, i32* %retval, align 4
1 Write   store i32 %argc, i32* %argc.addr, align 4
2 Write   store i8** %argv, i8*** %argv.addr, align 8
3 Write   store i32 1000, i32* %len, align 4, !dbg !21
4 Write   store i32 0, i32* %i, align 4, !dbg !27
5 Read   %2 = load i32, i32* %i, align 4, !dbg !30
6 Read   %3 = load i32, i32* %len, align 4, !dbg !32
7 Read   %4 = load i32, i32* %i, align 4, !dbg !35
8 Read   %5 = load i32, i32* %i, align 4, !dbg !37
9 Write   store i32 %4, i32* %arrayidx, align 4, !dbg !39
10 Read   %6 = load i32, i32* %i, align 4, !dbg !41
11 Write   store i32 %inc, i32* %i, align 4, !dbg !41
12 Write   store i8* getelementptr inbounds ([40 x i8], [40 x i8]* @1, i32 0, i32 0), i8** %7, align 8, !dbg !45
13 Fork   call void (%struct.ident_t*, i32, void (i32*, i32*, ...)*, ...) @__kmpc_fork_call(%struct.ident_t* %.kmpc_loc.addr, i32 2, void (i32*, i32*, ...)* bitcast (void (i32*, i32*, i32*, [1000 x i32]*)* @.omp_outlined. to void (i32*, i32*, ...)*), i32* %len, [1000 x i32]* %a), !dbg !45
14 Fork   call void (%struct.ident_t*, i32, void (i32*, i32*, ...)*, ...) @__kmpc_fork_call(%struct.ident_t* %.kmpc_loc.addr, i32 2, void (i32*, i32*, ...)* bitcast (void (i32*, i32*, i32*, [1000 x i32]*)* @.omp_outlined. to void (i32*, i32*, ...)*), i32* %len, [1000 x i32]* %a), !dbg !45
15 Join   call void (%struct.ident_t*, i32, void (i32*, i32*, ...)*, ...) @__kmpc_fork_call(%struct.ident_t* %.kmpc_loc.addr, i32 2, void (i32*, i32*, ...)* bitcast (void (i32*, i32*, i32*, [1000 x i32]*)* @.omp_outlined. to void (i32*, i32*, ...)*), i32* %len, [1000 x i32]* %a), !dbg !45
16 Join   call void (%struct.ident_t*, i32, void (i32*, i32*, ...)*, ...) @__kmpc_fork_call(%struct.ident_t* %.kmpc_loc.addr, i32 2, void (i32*, i32*, ...)* bitcast (void (i32*, i32*, i32*, [1000 x i32]*)* @.omp_outlined. to void (i32*, i32*, ...)*), i32* %len, [1000 x i32]* %a), !dbg !45
17 Read   %8 = load i32, i32* %arrayidx1, align 16, !dbg !46
----T1  (Spawned by T0:14)
0 Write   store i32* %.global_tid., i32** %.global_tid..addr, align 8
1 Write   store i32* %.bound_tid., i32** %.bound_tid..addr, align 8
2 Write   store i32* %len, i32** %len.addr, align 8
3 Write   store [1000 x i32]* %a, [1000 x i32]** %a.addr, align 8
...
```

Also made a slight change to the format races are printed by the openrace executable. Now it prints like

```
==== Races ====
pthreadsimple.c:8:9 pthreadsimple.c:8:9
          store i32 %inc, i32* @global, align 4, !dbg !53
          %0 = load i32, i32* @global, align 4, !dbg !53
pthreadsimple.c:8:9 pthreadsimple.c:8:9
          store i32 %inc, i32* @global, align 4, !dbg !53
          store i32 %inc, i32* @global, align 4, !dbg !53
```