### PR TITLE
add support for dumping json report

### DIFF
--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,5 +1,6 @@
 [requires]
 catch2/2.13.4
+nlohmann_json/3.9.1
 
 [generators]
 cmake

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,7 +44,7 @@ set(racedetect-lib-sources
     Reporter/Reporter.cpp
     RaceDetect.cpp)
 add_library(racedetect-lib STATIC ${racedetect-lib-sources})
-target_link_libraries(racedetect-lib pta)
+target_link_libraries(racedetect-lib pta CONAN_PKG::nlohmann_json)
 target_include_directories(racedetect-lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(openrace main.cpp)

--- a/src/RaceDetect.cpp
+++ b/src/RaceDetect.cpp
@@ -68,5 +68,7 @@ Report race::detectRaces(llvm::Module *module) {
 
   llvm::outs() << program << "\n";
 
+  // TODO: this is probably not the best place to call this function
+  reporter.dumpReport();
   return reporter.getReport();
 }

--- a/src/RaceDetect.cpp
+++ b/src/RaceDetect.cpp
@@ -68,7 +68,5 @@ Report race::detectRaces(llvm::Module *module) {
 
   llvm::outs() << program << "\n";
 
-  // TODO: this is probably not the best place to call this function
-  reporter.dumpReport();
   return reporter.getReport();
 }

--- a/src/Reporter/Reporter.cpp
+++ b/src/Reporter/Reporter.cpp
@@ -51,7 +51,7 @@ void race::to_json(json &j, const RaceAccess &access) {
   if (access.location.has_value()) {
     j = access.location.value();
   } else {
-    j = json{{"filename", ""}, {"dir", ""}, {"line", 0}, {"col", 0}};
+    llvm_unreachable("The report we serialize to JSON should only include races with valid locations");
   }
 };
 

--- a/src/Reporter/Reporter.h
+++ b/src/Reporter/Reporter.h
@@ -86,15 +86,25 @@ void to_json(json &j, const Race &race);
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Race &race);
 
-using Report = std::set<Race>;
+class Report {
+ public:
+  std::set<Race> races;
+
+  Report(std::vector<std::pair<const WriteEvent *, const MemAccessEvent *>> rawRaces);
+
+  inline bool empty() { return races.empty(); };
+  inline std::size_t size() { return races.size(); };
+
+  void dumpReport(const std::string &path = "race.json") const;
+};
+
 class Reporter {
-  std::vector<std::pair<const WriteEvent *, const MemAccessEvent *>> races;
+  std::vector<std::pair<const WriteEvent *, const MemAccessEvent *>> racepairs;
 
  public:
   void collect(const WriteEvent *e1, const MemAccessEvent *e2);
 
   [[nodiscard]] Report getReport() const;
-  void dumpReport() const;
 };
 
 }  // namespace race

--- a/src/Reporter/Reporter.h
+++ b/src/Reporter/Reporter.h
@@ -11,21 +11,25 @@ limitations under the License.
 
 #pragma once
 
+#include <nlohmann/json.hpp>
 #include <optional>
 
 #include "Trace/ProgramTrace.h"
 
 namespace race {
 
+using json = nlohmann::json;
+
 struct SourceLoc {
   llvm::StringRef filename;
+  llvm::StringRef directory;
   unsigned int line;
   unsigned int col;
 
   SourceLoc() = delete;
   SourceLoc(llvm::StringRef filename, unsigned int line, unsigned int col) : filename(filename), line(line), col(col) {}
   explicit SourceLoc(const llvm::DILocation *loc)
-      : filename(loc->getFilename()), line(loc->getLine()), col(loc->getColumn()) {}
+      : filename(loc->getFilename()), directory(loc->getDirectory()), line(loc->getLine()), col(loc->getColumn()) {}
 
   inline bool operator==(const SourceLoc &other) const {
     return filename == other.filename && line == other.line && col == other.col;
@@ -35,8 +39,12 @@ struct SourceLoc {
   bool operator<(const SourceLoc &other) const;
 };
 
+void to_json(json &j, const SourceLoc &loc);
+
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const SourceLoc &loc);
 
+// TODO: for now, RaceAccess only has `inst` in addition to SourceLoc, mostly for debugging purpose.
+// We need to include other debugging information, such as stacktrace in the future
 struct RaceAccess {
   // source location cannot always be identified
   std::optional<SourceLoc> location;
@@ -50,6 +58,8 @@ struct RaceAccess {
   bool operator!=(const RaceAccess &other) const;
   bool operator<(const RaceAccess &other) const;
 };
+
+void to_json(json &j, const RaceAccess &access);
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const std::optional<SourceLoc> &location);
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const RaceAccess &acc);
@@ -72,6 +82,8 @@ struct Race {
   }
 };
 
+void to_json(json &j, const Race &race);
+
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Race &race);
 
 using Report = std::set<Race>;
@@ -82,6 +94,7 @@ class Reporter {
   void collect(const WriteEvent *e1, const MemAccessEvent *e2);
 
   [[nodiscard]] Report getReport() const;
+  void dumpReport() const;
 };
 
 }  // namespace race

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,6 +53,7 @@ int main(int argc, char** argv) {
     llvm::outs() << race << "\n";
   }
   llvm::outs() << "Total Races Detected: " << report.size() << "\n";
+  llvm::outs() << "JSON Report generated at ./races.json";
 
   return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -49,10 +49,11 @@ int main(int argc, char** argv) {
 
   // TODO: should output to json or something and let something else handle displaying results
   llvm::outs() << "==== Races ====\n";
-  for (auto const& race : report) {
+  for (auto const& race : report.races) {
     llvm::outs() << race << "\n";
   }
   llvm::outs() << "Total Races Detected: " << report.size() << "\n";
+  report.dumpReport();
   llvm::outs() << "JSON Report generated at ./races.json";
 
   return 0;

--- a/tests/helpers/ReportChecking.cpp
+++ b/tests/helpers/ReportChecking.cpp
@@ -67,12 +67,12 @@ bool TestRace::equals(const race::Race &race) const {
 }
 
 bool reportContains(const race::Report &report, TestRace race) {
-  return std::find_if(report.begin(), report.end(),
-                      [&](const race::Race &reportRace) { return race.equals(reportRace); }) != report.end();
+  return std::find_if(report.races.begin(), report.races.end(),
+                      [&](const race::Race &reportRace) { return race.equals(reportRace); }) != report.races.end();
 }
 bool reportContains(const race::Report &report, std::vector<TestRace> races) {
   // loop over report, removing any matched races from the list of test races
-  for (auto const &reportRace : report) {
+  for (auto const &reportRace : report.races) {
     auto it = std::find_if(races.begin(), races.end(), [&](const TestRace &race) { return race.equals(reportRace); });
     if (it != races.end()) {
       races.erase(it);
@@ -102,7 +102,7 @@ void checkOracles(const std::vector<Oracle> &oracles, llvm::StringRef llPath) {
 
       auto report = race::detectRaces(module.get());
       llvm::errs() << "===> Detected Races:\n";
-      for (auto const &race : report) {
+      for (auto const &race : report.races) {
         llvm::errs() << race << "\n";
       }
       llvm::errs() << "\n";


### PR DESCRIPTION
This PR did following things:
1. Add nlohmann_json to our dependency
2. Add a function to dump JSON report to `./races.json`

The dumped JSON report will eventually correspond to the format defined at #57.
Currently, it's still incomplete, will gradually add supports to that once we support collecting more debugging information.