### PR TITLE
fix crash when thread is empty

### DIFF
--- a/src/Analysis/HappensBeforeGraph.cpp
+++ b/src/Analysis/HappensBeforeGraph.cpp
@@ -163,7 +163,10 @@ HappensBeforeGraph::HappensBeforeGraph(const race::ProgramTrace &program) {
             llvm::errs() << "Could not find fork!\n";
             continue;
           }
-          addSyncEdge(forkEvent, forkedThread->getEvents().front().get());
+          // If thread has no events just leave it out of happens before
+          if (!forkedThread->getEvents().empty()) {
+            addSyncEdge(forkEvent, forkedThread->getEvents().front().get());
+          }
           break;
         }
         case Event::Type::Join: {
@@ -174,7 +177,10 @@ HappensBeforeGraph::HappensBeforeGraph(const race::ProgramTrace &program) {
             llvm::errs() << "Could not find join!\n";
             continue;
           }
-          addSyncEdge(joinedThread->getEvents().back().get(), joinEvent);
+          // If thread has no events just leave it out of happens before
+          if (!joinedThread->getEvents().empty()) {
+            addSyncEdge(joinedThread->getEvents().back().get(), joinEvent);
+          }
           break;
         }
         case Event::Type::Read:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,8 @@ add_executable(tester
     integration/pthreadrace.test.cpp
     integration/dataracebench.test.cpp
 
+    regression/EmptyThread.test.cpp
+
     # Helper logic
     helpers/ReportChecking.cpp
 )

--- a/tests/regression/EmptyThread.test.cpp
+++ b/tests/regression/EmptyThread.test.cpp
@@ -1,0 +1,50 @@
+/* Copyright 2021 Coderrect Inc. All Rights Reserved.
+Licensed under the GNU Affero General Public License, version 3 or later (“AGPL”), as published by the Free Software
+Foundation. You may not use this file except in compliance with the License. You may obtain a copy of the License at
+https://www.gnu.org/licenses/agpl-3.0.en.html
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an “AS IS” BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <llvm/AsmParser/Parser.h>
+
+#include <catch2/catch.hpp>
+
+#include "Analysis/HappensBeforeGraph.h"
+
+TEST_CASE("No crash on empty thread", "[regression][happensbefore]") {
+  // Previously a bug caused HappensBefore to crash if a spawned thread contained no events
+
+  const char *ModuleString = R"(
+%union.pthread_attr_t = type { i64, [48 x i8] }
+
+define i8* @entry(i8*) {
+    ret i8* null
+}
+
+define void @main() {
+  %p_thread = alloca i64
+  %1 = call i32 @pthread_create(i64* %p_thread, %union.pthread_attr_t* null, i8* (i8*)* @entry, i8* null)
+  %thread = load i64, i64* %p_thread
+  %2 = call i32 @pthread_join(i64 %thread, i8** null)
+  ret void
+}
+
+declare i32 @pthread_create(i64*, %union.pthread_attr_t*, i8* (i8*)*, i8*)
+declare i32 @pthread_join(i64, i8**)
+)";
+
+  llvm::LLVMContext Ctx;
+  llvm::SMDiagnostic Err;
+  auto module = llvm::parseAssemblyString(ModuleString, Err, Ctx);
+  if (!module) {
+    Err.print("error", llvm::errs());
+  }
+
+  race::ProgramTrace program(module.get());
+
+  race::HappensBeforeGraph happensbefore(program);
+}


### PR DESCRIPTION
Happens Before Analysis was crashing when a thread has no events.
The analysis tries to add edges to/from the first/last events on a thread. When there were not events the analysis crashed.

This  change just skips threads with no events in happens before analysis.