### PR TITLE
Fix llvm style casts

### DIFF
--- a/src/Analysis/OmpArrayIndex.cpp
+++ b/src/Analysis/OmpArrayIndex.cpp
@@ -56,20 +56,21 @@ const std::vector<OmpArrayIndexAnalysis::LoopRegion>& OmpArrayIndexAnalysis::get
   std::optional<EventID> start;
 
   for (auto const& event : thread.getEvents()) {
-    auto const externCall = llvm::dyn_cast<ExternCallEvent>(event.get());
-    if (!externCall) continue;
-
-    auto const funcName = externCall->getCalledName();
-    if (!funcName.has_value()) continue;
-
-    if (OpenMPModel::isForStaticInit(funcName.value())) {
-      assert(!start.has_value() && "encountered two omp for inits in a row");
-      start = event->getID();
-    }
-    if (OpenMPModel::isForStaticFini(funcName.value())) {
-      assert(start.has_value() && "encountered omp for fini without a matching init");
-      loopRegions.emplace_back(start.value(), event->getID());
-      start.reset();
+    switch (event->getIRInst()->type) {
+      case IR::Type::OpenMPForInit: {
+        assert(!start.has_value() && "encountered two omp for inits in a row");
+        start = event->getID();
+        break;
+      }
+      case IR::Type::OpenMPForFini: {
+        assert(start.has_value() && "encountered omp for fini without a matching init");
+        loopRegions.emplace_back(start.value(), event->getID());
+        start.reset();
+        break;
+      }
+      default:
+        // Do Nothing
+        break;
     }
   }
 

--- a/src/IR/IR.h
+++ b/src/IR/IR.h
@@ -20,7 +20,36 @@ namespace race {
 
 class IR {
  public:
-  enum class Type { Read, Write, Fork, Lock, Unlock, Join, Call } type;
+  enum class Type {
+    Read,
+    Load,
+    APIRead,
+    END_Read,
+    Write,
+    Store,
+    APIWrite,
+    END_Write,
+    Fork,
+    PthreadCreate,
+    OpenMPFork,
+    END_Fork,
+    Join,
+    PthreadJoin,
+    OpenMPJoin,
+    END_Join,
+    Lock,
+    PthreadMutexLock,
+    PthreadSpinLock,
+    END_Lock,
+    Unlock,
+    PthreadMutexUnlock,
+    PthreadSpinUnlock,
+    END_Unlock,
+    Call,
+    OpenMPForInit,
+    OpenMPForFini,
+    END_Call
+  } type;
   [[nodiscard]] virtual const llvm::Instruction *getInst() const = 0;
 
   [[nodiscard]] virtual llvm::StringRef toString() const;
@@ -43,43 +72,46 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const IR::Type &type);
 // This is a convenience interface so that read/write can be kept in list
 // together
 class MemAccessIR : public IR {
+ protected:
+  using IR::IR;
+
  public:
   [[nodiscard]] virtual const llvm::Value *getAccessedValue() const = 0;
 
   // Used for llvm style RTTI (isa, dyn_cast, etc.)
-  static inline bool classof(const IR *e) { return e->type == Type::Read || e->type == Type::Write; }
+  static inline bool classof(const IR *e) { return e->type >= Type::Read || e->type <= Type::END_Write; }
 
  protected:
   explicit MemAccessIR(Type t) : IR(t) {
-    assert(t == Type::Read || t == Type::Write && "MemAccess constructed with non read/write type!");
+    assert(t >= Type::Read || t <= Type::END_Write && "MemAccess constructed with non read/write type!");
   }
 };
 
 class ReadIR : public MemAccessIR {
  protected:
-  ReadIR() : MemAccessIR(Type::Read) {}
+  using MemAccessIR::MemAccessIR;
 
  public:
   void print(llvm::raw_ostream &os) const override;
 
   // Used for llvm style RTTI (isa, dyn_cast, etc.)
-  static inline bool classof(const IR *e) { return e->type == Type::Read; }
+  static inline bool classof(const IR *e) { return e->type >= Type::Read && e->type < Type::END_Read; }
 };
 
 class WriteIR : public MemAccessIR {
  protected:
-  WriteIR() : MemAccessIR(Type::Write) {}
+  using MemAccessIR::MemAccessIR;
 
  public:
   void print(llvm::raw_ostream &os) const override;
 
   // Used for llvm style RTTI (isa, dyn_cast, etc.)
-  static inline bool classof(const IR *e) { return e->type == Type::Write; }
+  static inline bool classof(const IR *e) { return e->type >= Type::Write && e->type < Type::END_Write; }
 };
 
 class ForkIR : public IR {
  protected:
-  ForkIR() : IR(Type::Fork) {}
+  using IR::IR;
 
  public:
   // Get the handle for the thread being spawned.
@@ -95,12 +127,12 @@ class ForkIR : public IR {
   void print(llvm::raw_ostream &os) const override;
 
   // Used for llvm style RTTI (isa, dyn_cast, etc.)
-  static bool classof(const IR *e) { return e->type == Type::Fork; }
+  static bool classof(const IR *e) { return e->type >= Type::Fork && e->type < Type::END_Fork; }
 };
 
 class JoinIR : public IR {
  protected:
-  JoinIR() : IR(Type::Join) {}
+  using IR::IR;
 
  public:
   // Get the handle for the thread being joined.
@@ -111,12 +143,12 @@ class JoinIR : public IR {
   void print(llvm::raw_ostream &os) const override;
 
   // Used for llvm style RTTI (isa, dyn_cast, etc.)
-  static bool classof(const IR *e) { return e->type == Type::Join; }
+  static bool classof(const IR *e) { return e->type >= Type::Join && e->type < Type::END_Join; }
 };
 
 class LockIR : public IR {
  protected:
-  LockIR() : IR(Type::Lock) {}
+  using IR::IR;
 
  public:
   [[nodiscard]] virtual const llvm::Value *getLockValue() const = 0;
@@ -124,12 +156,12 @@ class LockIR : public IR {
   void print(llvm::raw_ostream &os) const override;
 
   // Used for llvm style RTTI (isa, dyn_cast, etc.)
-  static bool classof(const IR *e) { return e->type == Type::Lock; }
+  static bool classof(const IR *e) { return e->type >= Type::Lock && e->type < Type::END_Lock; }
 };
 
 class UnlockIR : public IR {
  protected:
-  UnlockIR() : IR(Type::Unlock) {}
+  using IR::IR;
 
  public:
   [[nodiscard]] virtual const llvm::Value *getLockValue() const = 0;
@@ -137,7 +169,7 @@ class UnlockIR : public IR {
   void print(llvm::raw_ostream &os) const override;
 
   // Used for llvm style RTTI (isa, dyn_cast, etc.)
-  static bool classof(const IR *e) { return e->type == Type::Unlock; }
+  static bool classof(const IR *e) { return e->type >= Type::Unlock && e->type < Type::END_Unlock; }
 };
 
 class CallIR : public IR {
@@ -153,7 +185,7 @@ class CallIR : public IR {
   [[nodiscard]] inline bool isIndirect() const { return inst->isIndirectCall(); }
 
   // Used for llvm style RTTI (isa, dyn_cast, etc.)
-  static bool classof(const IR *e) { return e->type == Type::Call; }
+  static bool classof(const IR *e) { return e->type >= Type::Call && e->type < Type::END_Call; }
 };
 
 }  // namespace race

--- a/src/IR/IR.h
+++ b/src/IR/IR.h
@@ -175,6 +175,10 @@ class UnlockIR : public IR {
 class CallIR : public IR {
   const llvm::CallBase *inst;
 
+ protected:
+  // Constructor for sub types
+  CallIR(const llvm::CallBase *inst, Type ty) : IR(ty), inst(inst) { assert(ty >= Type::Call && ty < Type::END_Call); }
+
  public:
   explicit CallIR(const llvm::CallBase *inst) : IR(Type::Call), inst(inst) {}
 

--- a/src/IR/IRImpls.h
+++ b/src/IR/IRImpls.h
@@ -25,11 +25,14 @@ class Load : public ReadIR {
   const llvm::LoadInst *inst;
 
  public:
-  explicit Load(const llvm::LoadInst *load) : inst(load) {}
+  explicit Load(const llvm::LoadInst *load) : ReadIR(Type::Load), inst(load) {}
 
   [[nodiscard]] inline const llvm::LoadInst *getInst() const override { return inst; }
 
   [[nodiscard]] inline const llvm::Value *getAccessedValue() const override { return inst->getPointerOperand(); }
+
+  // Used for llvm style RTTI (isa, dyn_cast, etc.)
+  static inline bool classof(const IR *e) { return e->type == Type::Load; }
 };
 
 class APIRead : public ReadIR {
@@ -40,11 +43,15 @@ class APIRead : public ReadIR {
 
  public:
   // API call that reads one of it's operands, specified by 'operandOffset'
-  APIRead(const llvm::CallBase *inst, unsigned int operandOffset) : operandOffset(operandOffset), inst(inst) {}
+  APIRead(const llvm::CallBase *inst, unsigned int operandOffset)
+      : ReadIR(Type::APIRead), operandOffset(operandOffset), inst(inst) {}
 
   [[nodiscard]] inline const llvm::CallBase *getInst() const override { return inst; }
 
   [[nodiscard]] inline const llvm::Value *getAccessedValue() const override { return inst->getOperand(operandOffset); }
+
+  // Used for llvm style RTTI (isa, dyn_cast, etc.)
+  static inline bool classof(const IR *e) { return e->type == Type::APIRead; }
 };
 
 // ==================================================================
@@ -55,11 +62,14 @@ class Store : public WriteIR {
   const llvm::StoreInst *inst;
 
  public:
-  explicit Store(const llvm::StoreInst *store) : inst(store) {}
+  explicit Store(const llvm::StoreInst *store) : WriteIR(Type::Store), inst(store) {}
 
   [[nodiscard]] inline const llvm::StoreInst *getInst() const override { return inst; }
 
   [[nodiscard]] inline const llvm::Value *getAccessedValue() const override { return inst->getPointerOperand(); }
+
+  // Used for llvm style RTTI (isa, dyn_cast, etc.)
+  static inline bool classof(const IR *e) { return e->type == Type::Store; }
 };
 
 class APIWrite : public WriteIR {
@@ -70,13 +80,17 @@ class APIWrite : public WriteIR {
 
  public:
   // API call that write to one of it's operands, specified by 'operandOffset'
-  APIWrite(const llvm::CallBase *inst, unsigned int operandOffset) : operandOffset(operandOffset), inst(inst) {}
+  APIWrite(const llvm::CallBase *inst, unsigned int operandOffset)
+      : WriteIR(Type::APIWrite), operandOffset(operandOffset), inst(inst) {}
 
   [[nodiscard]] inline const llvm::CallBase *getInst() const override { return inst; }
 
   [[nodiscard]] inline const llvm::Value *getAccessedValue() const override {
     return getInst()->getOperand(operandOffset);
   }
+
+  // Used for llvm style RTTI (isa, dyn_cast, etc.)
+  static inline bool classof(const IR *e) { return e->type == Type::APIWrite; }
 };
 
 // ==================================================================
@@ -89,7 +103,7 @@ class PthreadCreate : public ForkIR {
   const llvm::CallBase *inst;
 
  public:
-  explicit PthreadCreate(const llvm::CallBase *inst) : inst(inst) {}
+  explicit PthreadCreate(const llvm::CallBase *inst) : ForkIR(Type::PthreadCreate), inst(inst) {}
 
   [[nodiscard]] inline const llvm::CallBase *getInst() const override { return inst; }
 
@@ -100,6 +114,9 @@ class PthreadCreate : public ForkIR {
   [[nodiscard]] const llvm::Value *getThreadEntry() const override {
     return inst->getArgOperand(threadEntryOffset)->stripPointerCasts();
   }
+
+  // Used for llvm style RTTI (isa, dyn_cast, etc.)
+  static inline bool classof(const IR *e) { return e->type == Type::PthreadCreate; }
 };
 
 class OpenMPFork : public ForkIR {
@@ -114,7 +131,7 @@ class OpenMPFork : public ForkIR {
   const llvm::CallBase *inst;
 
  public:
-  explicit OpenMPFork(const llvm::CallBase *inst) : inst(inst) {}
+  explicit OpenMPFork(const llvm::CallBase *inst) : ForkIR(Type::OpenMPFork), inst(inst) {}
 
   [[nodiscard]] inline const llvm::CallBase *getInst() const override { return inst; }
 
@@ -125,6 +142,9 @@ class OpenMPFork : public ForkIR {
   [[nodiscard]] const llvm::Value *getThreadEntry() const override {
     return inst->getArgOperand(threadEntryOffset)->stripPointerCasts();
   }
+
+  // Used for llvm style RTTI (isa, dyn_cast, etc.)
+  static inline bool classof(const IR *e) { return e->type == Type::OpenMPFork; }
 };
 
 // ==================================================================
@@ -136,13 +156,16 @@ class PthreadJoin : public JoinIR {
   const llvm::CallBase *inst;
 
  public:
-  explicit PthreadJoin(const llvm::CallBase *inst) : inst(inst) {}
+  explicit PthreadJoin(const llvm::CallBase *inst) : JoinIR(Type::PthreadJoin), inst(inst) {}
 
   [[nodiscard]] inline const llvm::CallBase *getInst() const override { return inst; }
 
   [[nodiscard]] const llvm::Value *getThreadHandle() const override {
     return inst->getArgOperand(threadHandleOffset)->stripPointerCasts();
   }
+
+  // Used for llvm style RTTI (isa, dyn_cast, etc.)
+  static inline bool classof(const IR *e) { return e->type == Type::PthreadJoin; }
 };
 
 // This actually corresponds to a OpenMP fork instruction, as the fork call acts as both a fork and join in one call
@@ -150,64 +173,85 @@ class OpenMPJoin : public JoinIR {
   std::shared_ptr<OpenMPFork> fork;
 
  public:
-  explicit OpenMPJoin(const std::shared_ptr<OpenMPFork> fork) : fork(fork) {}
+  explicit OpenMPJoin(const std::shared_ptr<OpenMPFork> fork) : JoinIR(Type::OpenMPJoin), fork(fork) {}
 
   [[nodiscard]] inline const llvm::CallBase *getInst() const override { return fork->getInst(); }
 
   [[nodiscard]] const llvm::Value *getThreadHandle() const override { return fork->getThreadHandle(); }
+
+  // Used for llvm style RTTI (isa, dyn_cast, etc.)
+  static inline bool classof(const IR *e) { return e->type == Type::OpenMPJoin; }
 };
 
 // ==================================================================
 // ================== LockIR Implementations ========================
 // ==================================================================
 
+template <IR::Type T>
 class LockIRImpl : public LockIR {
   const unsigned int lockObjectOffset = 0;
   const llvm::CallBase *inst;
 
  public:
-  explicit LockIRImpl(const llvm::CallBase *call) : inst(call) {}
+  explicit LockIRImpl(const llvm::CallBase *call) : LockIR(T), inst(call) {}
 
   [[nodiscard]] inline const llvm::CallBase *getInst() const override { return inst; }
 
   [[nodiscard]] const llvm::Value *getLockValue() const override {
     return inst->getArgOperand(lockObjectOffset)->stripPointerCasts();
   }
+
+  // Used for llvm style RTTI (isa, dyn_cast, etc.)
+  static inline bool classof(const IR *e) { return e->type == T; }
 };
 
 // NOTE: if a specific API semantic is the same as default impl,
 // create a type alias.
-using PthreadMutexLock = LockIRImpl;
-using PthreadSpinLock = LockIRImpl;
+using PthreadMutexLock = LockIRImpl<IR::Type::PthreadMutexLock>;
+using PthreadSpinLock = LockIRImpl<IR::Type::PthreadSpinLock>;
 
 // ==================================================================
 // ================= UnlockIR Implementations =======================
 // ==================================================================
 
+template <IR::Type T>
 class UnlockIRImpl : public UnlockIR {
   const unsigned int lockObjectOffset = 0;
   const llvm::CallBase *inst;
 
  public:
-  explicit UnlockIRImpl(const llvm::CallBase *call) : inst(call) {}
+  explicit UnlockIRImpl(const llvm::CallBase *call) : UnlockIR(T), inst(call) {}
 
   [[nodiscard]] inline const llvm::CallBase *getInst() const override { return inst; }
 
   [[nodiscard]] const llvm::Value *getLockValue() const override {
     return inst->getArgOperand(lockObjectOffset)->stripPointerCasts();
   }
+
+  // Used for llvm style RTTI (isa, dyn_cast, etc.)
+  static inline bool classof(const IR *e) { return e->type == T; }
 };
 
 // NOTE: if a specific API semantic is the same as default impl,
 // create a type alias.
-using PthreadMutexUnlock = UnlockIRImpl;
-using PthreadSpinUnlock = UnlockIRImpl;
+using PthreadMutexUnlock = UnlockIRImpl<IR::Type::PthreadMutexUnlock>;
+using PthreadSpinUnlock = UnlockIRImpl<IR::Type::PthreadSpinUnlock>;
 
 // ==================================================================
 // ================= Other Implementations =======================
 // ==================================================================
 
+// template <const IR::Type T>
+// class CallIRImpl : public CallIR {
+//  public:
+//   // Used for llvm style RTTI (isa, dyn_cast, etc.)
+//   static inline bool classof(const IR *e) { return e->type == T; }
+// };
+
 // No special API or info needed from these. Just include them IR to see where omp loops start/end
+// using OmpForInit = CallIRImpl<IR::Type::OpenMPForInit>;
+// using OmpForFini = CallIRImpl<IR::Type::OpenMPForFini>;
+
 using OmpForInit = CallIR;
 using OmpForFini = CallIR;
 

--- a/src/IR/IRImpls.h
+++ b/src/IR/IRImpls.h
@@ -241,18 +241,16 @@ using PthreadSpinUnlock = UnlockIRImpl<IR::Type::PthreadSpinUnlock>;
 // ================= Other Implementations =======================
 // ==================================================================
 
-// template <const IR::Type T>
-// class CallIRImpl : public CallIR {
-//  public:
-//   // Used for llvm style RTTI (isa, dyn_cast, etc.)
-//   static inline bool classof(const IR *e) { return e->type == T; }
-// };
+template <const IR::Type T>
+class CallIRImpl : public CallIR {
+ public:
+  CallIRImpl(const llvm::CallBase *inst) : CallIR(inst, T) {}
 
-// No special API or info needed from these. Just include them IR to see where omp loops start/end
-// using OmpForInit = CallIRImpl<IR::Type::OpenMPForInit>;
-// using OmpForFini = CallIRImpl<IR::Type::OpenMPForFini>;
+  // Used for llvm style RTTI (isa, dyn_cast, etc.)
+  static inline bool classof(const IR *e) { return e->type == T; }
+};
 
-using OmpForInit = CallIR;
-using OmpForFini = CallIR;
+using OmpForInit = CallIRImpl<IR::Type::OpenMPForInit>;
+using OmpForFini = CallIRImpl<IR::Type::OpenMPForFini>;
 
 }  // namespace race


### PR DESCRIPTION
Added a unique IR::Type for each concrete class, as is recommended by LLVM's documentation.

Without this there might be a bug where a pointer can be casted to a type incorrectly. 

```cpp
const pthreadFork = new PthreadFork(); // Type is pthreadfork, but IR::Type is just Fork
const Fork *fork = pthreadFork; // Upcast is fine
const OmpFork *ompfork = dyn_cast<OmpFork>(fork); // Up cast works because IR::Type is still Fork
```

Adding unique IR::Types for each concrete class fixes this problem, and allows us to tell which type of instruction an LLVM IR instruction came from without having to rely on `LanguageModel::is*` functions. See changes to `src/Analysis/OmpArrayIndex.cpp` for an example.