### PR TITLE
Add support for OpenMP Single

### DIFF
--- a/src/Analysis/OmpArrayIndex.cpp
+++ b/src/Analysis/OmpArrayIndex.cpp
@@ -96,10 +96,9 @@ bool OmpArrayIndexAnalysis::isInOmpFor(const race::MemAccessEvent* event) {
   auto loopRegions = getOmpForLoops(event->getThread());
   auto const eid = event->getID();
   for (auto const& region : loopRegions) {
-    if (eid > region.start) {
-      continue;
-    }
-    return eid > region.end;
+    // Look for eid after start event but before end event
+    // regions are not nested so as soon as eid is past region start we can return answer
+    if (eid > region.start) return eid < region.end;
   }
 
   return false;

--- a/src/Analysis/OmpArrayIndex.h
+++ b/src/Analysis/OmpArrayIndex.h
@@ -18,12 +18,21 @@ limitations under the License.
 
 namespace race {
 
+struct Region {
+  EventID start;
+  EventID end;
+
+  Region(EventID start, EventID end) : start(start), end(end) {}
+
+  inline bool contains(EventID e) const { return start <= e && end >= e; }
+};
+
 class OmpArrayIndexAnalysis {
   llvm::PassBuilder PB;
   llvm::FunctionAnalysisManager FAM;
 
   // Start/End of omp loop
-  using LoopRegion = std::pair<EventID, EventID>;
+  using LoopRegion = Region;
 
   // per-thread map of omp for loop regions
   std::map<ThreadID, std::vector<LoopRegion>> ompForLoops;
@@ -43,7 +52,11 @@ class OmpArrayIndexAnalysis {
   bool isOmpLoopArrayAccess(const race::MemAccessEvent* event1, const race::MemAccessEvent* event2);
 
   // return true if both events are part of the same omp team
-  bool inSameTeam(const Event* lhs, const Event* rhs);
+  bool inSameTeam(const Event* lhs, const Event* rhs) const;
+
+  // return true if both events are in the same single region
+  // Call assumes the events are on different threads but in the same team
+  bool inSameSingleBlock(const Event* lhs, const Event* rhs) const;
 };
 
 }  // namespace race

--- a/src/Analysis/OmpArrayIndex.h
+++ b/src/Analysis/OmpArrayIndex.h
@@ -41,6 +41,9 @@ class OmpArrayIndexAnalysis {
 
   // return true if both events are array accesses in an omp loop
   bool isOmpLoopArrayAccess(const race::MemAccessEvent* event1, const race::MemAccessEvent* event2);
+
+  // return true if both events are part of the same omp team
+  bool inSameTeam(const Event* lhs, const Event* rhs);
 };
 
 }  // namespace race

--- a/src/Analysis/OpenMPAnalysis.cpp
+++ b/src/Analysis/OpenMPAnalysis.cpp
@@ -96,9 +96,9 @@ bool OpenMPAnalysis::inParallelFor(const race::MemAccessEvent* event) {
   auto loopRegions = getOmpForLoops(event->getThread());
   auto const eid = event->getID();
   for (auto const& region : loopRegions) {
-    // Look for eid after start event but before end event
-    // regions are not nested so as soon as eid is past region start we can return answer
-    if (eid > region.start) return eid < region.end;
+    if (region.contains(eid)) return true;
+    // Break early if we pass the eid without finding matching region
+    if (region.end > eid) return false;
   }
 
   return false;

--- a/src/Analysis/OpenMPAnalysis.h
+++ b/src/Analysis/OpenMPAnalysis.h
@@ -24,7 +24,7 @@ struct Region {
 
   Region(EventID start, EventID end) : start(start), end(end) {}
 
-  inline bool contains(EventID e) const { return start <= e && end >= e; }
+  inline bool contains(EventID e) const { return start <= e && e <= end; }
 };
 
 class OpenMPAnalysis {
@@ -52,11 +52,11 @@ class OpenMPAnalysis {
   bool isLoopArrayAccess(const race::MemAccessEvent* event1, const race::MemAccessEvent* event2);
 
   // return true if both events are part of the same omp team
-  bool inSameTeam(const Event* lhs, const Event* rhs) const;
+  bool inSameTeam(const Event* event1, const Event* event2) const;
 
   // return true if both events are in the same single region
   // Call assumes the events are on different threads but in the same team
-  bool inSameSingleBlock(const Event* lhs, const Event* rhs) const;
+  bool inSameSingleBlock(const Event* event1, const Event* event2) const;
 };
 
 }  // namespace race

--- a/src/Analysis/OpenMPAnalysis.h
+++ b/src/Analysis/OpenMPAnalysis.h
@@ -24,7 +24,7 @@ struct Region {
 
   Region(EventID start, EventID end) : start(start), end(end) {}
 
-  inline bool contains(EventID e) const { return start <= e && e <= end; }
+  inline bool contains(EventID e) const { return end >= e && e >= start; }
 };
 
 class OpenMPAnalysis {

--- a/src/Analysis/OpenMPAnalysis.h
+++ b/src/Analysis/OpenMPAnalysis.h
@@ -27,7 +27,7 @@ struct Region {
   inline bool contains(EventID e) const { return start <= e && end >= e; }
 };
 
-class OmpArrayIndexAnalysis {
+class OpenMPAnalysis {
   llvm::PassBuilder PB;
   llvm::FunctionAnalysisManager FAM;
 
@@ -40,16 +40,16 @@ class OmpArrayIndexAnalysis {
   // get cached list of loop regions, else create them
   const std::vector<LoopRegion>& getOmpForLoops(const ThreadTrace& trace);
 
-  bool isInOmpFor(const race::MemAccessEvent* event);
+  bool inParallelFor(const race::MemAccessEvent* event);
 
  public:
-  OmpArrayIndexAnalysis();
+  OpenMPAnalysis();
 
   // return true if events are array accesses who's access sets could overlap
   bool canIndexOverlap(const race::MemAccessEvent* event1, const race::MemAccessEvent* event2);
 
   // return true if both events are array accesses in an omp loop
-  bool isOmpLoopArrayAccess(const race::MemAccessEvent* event1, const race::MemAccessEvent* event2);
+  bool isLoopArrayAccess(const race::MemAccessEvent* event1, const race::MemAccessEvent* event2);
 
   // return true if both events are part of the same omp team
   bool inSameTeam(const Event* lhs, const Event* rhs) const;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,7 +35,7 @@ set(racedetect-lib-sources
     Analysis/HappensBeforeGraph.cpp
     Analysis/LockSet.cpp
     Analysis/SharedMemory.cpp
-    Analysis/OmpArrayIndex.cpp
+    Analysis/OpenMPAnalysis.cpp
     IR/Builder.cpp
     IR/IR.cpp
     Trace/Event.cpp

--- a/src/IR/Builder.cpp
+++ b/src/IR/Builder.cpp
@@ -110,6 +110,10 @@ FunctionSummary race::generateFunctionSummary(const llvm::Function &func) {
           instructions.push_back(std::make_shared<OmpForInit>(callInst));
         } else if (OpenMPModel::isForStaticFini(funcName)) {
           instructions.push_back(std::make_shared<OmpForFini>(callInst));
+        } else if (OpenMPModel::isSingleStart(funcName)) {
+          instructions.push_back(std::make_shared<OpenMPSingleStart>(callInst));
+        } else if (OpenMPModel::isSingleEnd(funcName)) {
+          instructions.push_back(std::make_shared<OpenMPSingleEnd>(callInst));
         } else if (OpenMPModel::isFork(funcName)) {
           // duplicate omp preprocessing should duplicate all omp fork calls
           auto ompFork = std::make_shared<OpenMPFork>(callInst);

--- a/src/IR/IR.h
+++ b/src/IR/IR.h
@@ -48,6 +48,8 @@ class IR {
     Call,
     OpenMPForInit,
     OpenMPForFini,
+    OpenMPSingleStart,
+    OpenMPSingleEnd,
     END_Call
   } type;
   [[nodiscard]] virtual const llvm::Instruction *getInst() const = 0;

--- a/src/IR/IRImpls.h
+++ b/src/IR/IRImpls.h
@@ -259,4 +259,7 @@ class CallIRImpl : public CallIR {
 using OmpForInit = CallIRImpl<IR::Type::OpenMPForInit>;
 using OmpForFini = CallIRImpl<IR::Type::OpenMPForFini>;
 
+using OpenMPSingleStart = CallIRImpl<IR::Type::OpenMPSingleStart>;
+using OpenMPSingleEnd = CallIRImpl<IR::Type::OpenMPSingleEnd>;
+
 }  // namespace race

--- a/src/LanguageModel/OpenMP.h
+++ b/src/LanguageModel/OpenMP.h
@@ -23,7 +23,11 @@ inline bool isFork(const llvm::CallBase* callInst) {
   if (!func->hasName()) return false;
   return isFork(func->getName());
 }
+
 inline bool isForStaticInit(const llvm::StringRef& funcName) { return funcName.equals("__kmpc_for_static_init_4"); }
 inline bool isForStaticFini(const llvm::StringRef& funcName) { return funcName.equals("__kmpc_for_static_fini"); }
+
+inline bool isSingleStart(const llvm::StringRef& funcName) { return funcName.equals("__kmpc_single"); }
+inline bool isSingleEnd(const llvm::StringRef& funcName) { return funcName.equals("__kmpc_end_single"); }
 
 }  // namespace OpenMPModel

--- a/src/RaceDetect.cpp
+++ b/src/RaceDetect.cpp
@@ -13,7 +13,7 @@ limitations under the License.
 
 #include "Analysis/HappensBeforeGraph.h"
 #include "Analysis/LockSet.h"
-#include "Analysis/OmpArrayIndex.h"
+#include "Analysis/OpenMPAnalysis.h"
 #include "Analysis/SharedMemory.h"
 #include "LanguageModel/RaceModel.h"
 #include "PreProcessing/PreProcessing.h"
@@ -28,7 +28,7 @@ Report race::detectRaces(llvm::Module *module) {
   race::SharedMemory sharedmem(program);
   race::HappensBeforeGraph happensbefore(program);
   race::LockSet lockset(program);
-  race::OmpArrayIndexAnalysis ompAnalysis;
+  race::OpenMPAnalysis ompAnalysis;
 
   // Adds to report if race is detected between write and other
   auto checkRace = [&](const race::WriteEvent *write, const race::MemAccessEvent *other) {
@@ -37,7 +37,7 @@ Report race::detectRaces(llvm::Module *module) {
     }
 
     if (ompAnalysis.inSameTeam(write, other)) {
-      if (ompAnalysis.isOmpLoopArrayAccess(write, other) && !ompAnalysis.canIndexOverlap(write, other)) {
+      if (ompAnalysis.isLoopArrayAccess(write, other) && !ompAnalysis.canIndexOverlap(write, other)) {
         return;
       }
 

--- a/src/RaceDetect.cpp
+++ b/src/RaceDetect.cpp
@@ -36,8 +36,14 @@ Report race::detectRaces(llvm::Module *module) {
       return;
     }
 
-    if (ompAnalysis.isOmpLoopArrayAccess(write, other) && !ompAnalysis.canIndexOverlap(write, other)) {
-      return;
+    if (ompAnalysis.inSameTeam(write, other)) {
+      if (ompAnalysis.isOmpLoopArrayAccess(write, other) && !ompAnalysis.canIndexOverlap(write, other)) {
+        return;
+      }
+
+      if (ompAnalysis.inSameSingleBlock(write, other)) {
+        return;
+      }
     }
 
     // Race detected

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(tester
     unit/Analysis/HappensBefore.test.cpp
     unit/Analysis/LockSet.test.cpp
     unit/Analysis/SharedMemory.test.cpp
-    unit/Analysis/OmpArrayIndex.test.cpp
+    unit/Analysis/OpenMPAnalysis.test.cpp
     unit/IR/IR.test.cpp
     unit/IR/OpenMPIR.test.cpp
     unit/PointerAnalysis/PointerAnalysis.test.cpp

--- a/tests/unit/Analysis/OmpArrayIndex.test.cpp
+++ b/tests/unit/Analysis/OmpArrayIndex.test.cpp
@@ -156,3 +156,86 @@ declare void @__kmpc_fork_call(%struct.ident_t*, i32, void (i32*, i32*, ...)*, .
   check_not_same_team(*threads.at(2), *threads.at(3));
   check_not_same_team(*threads.at(2), *threads.at(4));
 }
+
+TEST_CASE("OpenMP inSameSingleRegion Analysis") {
+  const char *ModuleString = R"(
+%struct.ident_t = type { i32, i32, i32, i32, i8* }
+
+@count = dso_local global i32 0, align 4
+@0 = private unnamed_addr constant [23 x i8] c";unknown;unknown;0;0;;\00", align 1
+@1 = private unnamed_addr constant %struct.ident_t { i32 0, i32 2, i32 0, i32 0, i8* getelementptr inbounds ([23 x i8], [23 x i8]* @0, i32 0, i32 0) }, align 8
+
+; Function Attrs: noinline nounwind optnone sspstrong uwtable
+define dso_local i32 @main() {
+entry:
+  call void (%struct.ident_t*, i32, void (i32*, i32*, ...)*, ...) @__kmpc_fork_call(%struct.ident_t* @1, i32 0, void (i32*, i32*, ...)* bitcast (void (i32*, i32*)* @.omp_outlined. to void (i32*, i32*, ...)*))
+  ret i32 0
+}
+
+; Function Attrs: noinline norecurse nounwind optnone sspstrong uwtable
+define internal void @.omp_outlined.(i32* noalias %.global_tid., i32* noalias %.bound_tid.) {
+entry:
+  %.kmpc_loc.addr = alloca %struct.ident_t
+
+  %start1 = call i32 @__kmpc_single(%struct.ident_t* %.kmpc_loc.addr, i32 0)
+  %0 = load i32, i32* @count, align 4
+  call void @__kmpc_end_single(%struct.ident_t* %.kmpc_loc.addr, i32 0)
+  
+  %inc = add nsw i32 %0, 1
+
+  %start2 = call i32 @__kmpc_single(%struct.ident_t* %.kmpc_loc.addr, i32 0)
+  store i32 %inc, i32* @count, align 4
+  call void @__kmpc_end_single(%struct.ident_t* %.kmpc_loc.addr, i32 0)
+
+  ret void
+}
+
+; Function Attrs: nounwind
+declare void @__kmpc_fork_call(%struct.ident_t*, i32, void (i32*, i32*, ...)*, ...)
+declare dso_local void @__kmpc_end_single(%struct.ident_t*, i32)
+declare dso_local i32 @__kmpc_single(%struct.ident_t*, i32)
+
+)";
+  llvm::LLVMContext Ctx;
+  llvm::SMDiagnostic Err;
+  auto module = llvm::parseAssemblyString(ModuleString, Err, Ctx);
+  if (!module) {
+    Err.print("error", llvm::errs());
+    FAIL("no module");
+  }
+
+  race::ProgramTrace program(module.get());
+  race::OmpArrayIndexAnalysis arrayIndexAnalysis;
+
+  auto const &threads = program.getThreads();
+  REQUIRE(threads.size() == 3);
+
+  auto check_same_team = [&arrayIndexAnalysis](const race::ThreadTrace &t1, const race::ThreadTrace &t2) {
+    for (auto const &e1 : t1.getEvents()) {
+      for (auto const &e2 : t2.getEvents()) {
+        CHECK(arrayIndexAnalysis.inSameTeam(e1.get(), e2.get()));
+      }
+    }
+  };
+
+  auto check_not_same_team = [&arrayIndexAnalysis](const race::ThreadTrace &t1, const race::ThreadTrace &t2) {
+    for (auto const &e1 : t1.getEvents()) {
+      for (auto const &e2 : t2.getEvents()) {
+        CHECK_FALSE(arrayIndexAnalysis.inSameTeam(e1.get(), e2.get()));
+      }
+    }
+  };
+  llvm::errs() << program << "\n";
+
+  auto const &e11 = program.getEvent(1, 1);
+  auto const &e14 = program.getEvent(1, 4);
+
+  auto const &e21 = program.getEvent(2, 1);
+  auto const &e24 = program.getEvent(2, 4);
+
+  CHECK(arrayIndexAnalysis.inSameSingleBlock(e11, e21));
+  CHECK(arrayIndexAnalysis.inSameSingleBlock(e14, e24));
+
+  CHECK_FALSE(arrayIndexAnalysis.inSameSingleBlock(e11, e24));
+  CHECK_FALSE(arrayIndexAnalysis.inSameSingleBlock(e14, e21));
+}

--- a/tests/unit/Analysis/OmpArrayIndex.test.cpp
+++ b/tests/unit/Analysis/OmpArrayIndex.test.cpp
@@ -9,6 +9,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#include <llvm/AsmParser/Parser.h>
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IRReader/IRReader.h>
 #include <llvm/Support/SourceMgr.h>
@@ -69,4 +70,89 @@ TEST_CASE("Omp Array Index Alias Analysis", "[unit][omp]") {
     UNSCOPED_INFO("Checking for alias between " << puidStr(pair.first) << " and " << puidStr(pair.second));
     CHECK(arrayIndexAnalysis.canIndexOverlap(e1, e2));
   }
+}
+
+TEST_CASE("OpenMP inSameTeam Analysis") {
+  const char *ModuleString = R"(
+%struct.ident_t = type { i32, i32, i32, i32, i8* }
+
+@count = dso_local global i32 0, align 4
+@0 = private unnamed_addr constant [23 x i8] c";unknown;unknown;0;0;;\00", align 1
+@1 = private unnamed_addr constant %struct.ident_t { i32 0, i32 2, i32 0, i32 0, i8* getelementptr inbounds ([23 x i8], [23 x i8]* @0, i32 0, i32 0) }, align 8
+
+; Function Attrs: noinline nounwind optnone sspstrong uwtable
+define dso_local i32 @main() {
+entry:
+  call void (%struct.ident_t*, i32, void (i32*, i32*, ...)*, ...) @__kmpc_fork_call(%struct.ident_t* @1, i32 0, void (i32*, i32*, ...)* bitcast (void (i32*, i32*)* @.omp_outlined. to void (i32*, i32*, ...)*))
+  call void (%struct.ident_t*, i32, void (i32*, i32*, ...)*, ...) @__kmpc_fork_call(%struct.ident_t* @1, i32 0, void (i32*, i32*, ...)* bitcast (void (i32*, i32*)* @.omp_outlined..1 to void (i32*, i32*, ...)*))
+  ret i32 0
+}
+
+; Function Attrs: noinline norecurse nounwind optnone sspstrong uwtable
+define internal void @.omp_outlined.(i32* noalias %.global_tid., i32* noalias %.bound_tid.) {
+entry:
+  %.global_tid..addr = alloca i32*, align 8
+  %.bound_tid..addr = alloca i32*, align 8
+  store i32* %.global_tid., i32** %.global_tid..addr, align 8
+  store i32* %.bound_tid., i32** %.bound_tid..addr, align 8
+  %0 = load i32, i32* @count, align 4
+  %inc = add nsw i32 %0, 1
+  store i32 %inc, i32* @count, align 4
+  ret void
+}
+
+; Function Attrs: noinline norecurse nounwind optnone sspstrong uwtable
+define internal void @.omp_outlined..1(i32* noalias %.global_tid., i32* noalias %.bound_tid.) {
+entry:
+  %.global_tid..addr = alloca i32*, align 8
+  %.bound_tid..addr = alloca i32*, align 8
+  store i32* %.global_tid., i32** %.global_tid..addr, align 8
+  store i32* %.bound_tid., i32** %.bound_tid..addr, align 8
+  %0 = load i32, i32* @count, align 4
+  %inc = add nsw i32 %0, 1
+  store i32 %inc, i32* @count, align 4
+  ret void
+}
+
+; Function Attrs: nounwind
+declare void @__kmpc_fork_call(%struct.ident_t*, i32, void (i32*, i32*, ...)*, ...)
+
+)";
+  llvm::LLVMContext Ctx;
+  llvm::SMDiagnostic Err;
+  auto module = llvm::parseAssemblyString(ModuleString, Err, Ctx);
+  if (!module) {
+    Err.print("error", llvm::errs());
+    FAIL("no module");
+  }
+
+  race::ProgramTrace program(module.get());
+  race::OmpArrayIndexAnalysis arrayIndexAnalysis;
+
+  auto const &threads = program.getThreads();
+  REQUIRE(threads.size() == 5);
+
+  auto check_same_team = [&arrayIndexAnalysis](const race::ThreadTrace &t1, const race::ThreadTrace &t2) {
+    for (auto const &e1 : t1.getEvents()) {
+      for (auto const &e2 : t2.getEvents()) {
+        CHECK(arrayIndexAnalysis.inSameTeam(e1.get(), e2.get()));
+      }
+    }
+  };
+
+  auto check_not_same_team = [&arrayIndexAnalysis](const race::ThreadTrace &t1, const race::ThreadTrace &t2) {
+    for (auto const &e1 : t1.getEvents()) {
+      for (auto const &e2 : t2.getEvents()) {
+        CHECK_FALSE(arrayIndexAnalysis.inSameTeam(e1.get(), e2.get()));
+      }
+    }
+  };
+
+  check_same_team(*threads.at(1), *threads.at(2));
+  check_same_team(*threads.at(3), *threads.at(4));
+
+  check_not_same_team(*threads.at(1), *threads.at(3));
+  check_not_same_team(*threads.at(1), *threads.at(4));
+  check_not_same_team(*threads.at(2), *threads.at(3));
+  check_not_same_team(*threads.at(2), *threads.at(4));
 }

--- a/tests/unit/Analysis/OpenMPAnalysis.test.cpp
+++ b/tests/unit/Analysis/OpenMPAnalysis.test.cpp
@@ -18,7 +18,7 @@ limitations under the License.
 #include <catch2/catch.hpp>
 #include <sstream>
 
-#include "Analysis/OmpArrayIndex.h"
+#include "Analysis/OpenMPAnalysis.h"
 #include "Trace/ProgramTrace.h"
 
 TEST_CASE("Omp Array Index Alias Analysis", "[unit][omp]") {
@@ -33,7 +33,7 @@ TEST_CASE("Omp Array Index Alias Analysis", "[unit][omp]") {
   REQUIRE(module.get() != nullptr);
 
   race::ProgramTrace program(module.get());
-  race::OmpArrayIndexAnalysis arrayIndexAnalysis;
+  race::OpenMPAnalysis arrayIndexAnalysis;
 
   // TODO: Make Program unique event ID a type in Trace
   using PUID = std::pair<race::ThreadID, race::EventID>;
@@ -127,7 +127,7 @@ declare void @__kmpc_fork_call(%struct.ident_t*, i32, void (i32*, i32*, ...)*, .
   }
 
   race::ProgramTrace program(module.get());
-  race::OmpArrayIndexAnalysis arrayIndexAnalysis;
+  race::OpenMPAnalysis arrayIndexAnalysis;
 
   auto const &threads = program.getThreads();
   REQUIRE(threads.size() == 5);
@@ -205,7 +205,7 @@ declare dso_local i32 @__kmpc_single(%struct.ident_t*, i32)
   }
 
   race::ProgramTrace program(module.get());
-  race::OmpArrayIndexAnalysis arrayIndexAnalysis;
+  race::OpenMPAnalysis arrayIndexAnalysis;
 
   auto const &threads = program.getThreads();
   REQUIRE(threads.size() == 3);


### PR DESCRIPTION
This PR adds support for [OpenMP single](https://www.openmp.org/spec-html/5.0/openmpsu38.html#x60-1090002.8.2)

The basic idea is add a filter to the main race detection logic to filter racing pairs that occur within the same "single" block.
Single blocks are identified by the `kmpc_single` and `kmpc_end_single` calls.