### PR TITLE
Add config for dumping json and preprocessed ir

### DIFF
--- a/src/RaceDetect.h
+++ b/src/RaceDetect.h
@@ -15,6 +15,11 @@ limitations under the License.
 
 namespace race {
 
-Report detectRaces(llvm::Module *module);
+struct DetectRaceConfig {
+  // writes preprocessedIR to a file specified by the string
+  std::optional<std::string> dumpPreprocessedIR;
+};
+
+Report detectRaces(llvm::Module *module, DetectRaceConfig config = DetectRaceConfig());
 
 }  // namespace race

--- a/src/Trace/ProgramTrace.cpp
+++ b/src/Trace/ProgramTrace.cpp
@@ -16,7 +16,7 @@ limitations under the License.
 
 using namespace race;
 
-ProgramTrace::ProgramTrace(llvm::Module *module, llvm::StringRef entryName) {
+ProgramTrace::ProgramTrace(llvm::Module *module, llvm::StringRef entryName) : module(module) {
   // Run preprocessing on module
   preprocess(*module);
 

--- a/src/Trace/ProgramTrace.h
+++ b/src/Trace/ProgramTrace.h
@@ -22,6 +22,8 @@ namespace race {
 class ProgramTrace {
   std::vector<std::unique_ptr<ThreadTrace>> threads;
 
+  llvm::Module *module;
+
  public:
   pta::PTA pta;
 
@@ -29,7 +31,10 @@ class ProgramTrace {
 
   [[nodiscard]] const Event *getEvent(ThreadID tid, EventID eid) { return threads.at(tid)->getEvent(eid); }
 
-  explicit ProgramTrace(llvm::Module *, llvm::StringRef entryName = "main");
+  // Get the module after preprocessing has been run
+  [[nodiscard]] const Module &getModule() const { return *module; }
+
+  explicit ProgramTrace(llvm::Module *module, llvm::StringRef entryName = "main");
   ~ProgramTrace() = default;
   ProgramTrace(const ProgramTrace &) = delete;
   ProgramTrace(ProgramTrace &&) = delete;  // Need to update threads because


### PR DESCRIPTION
I added a command line option to dump the preprocessed ir for debugging another issue. The flag `-dump-ir=mod.ll` will write the modified ir to `mod.ll`.

I also added a similar config for the json race report. The flag `-json=races.json` will write the json race report to `races.json`.

By default neither are written as most of the time we run the tool manually or in tests, we do not want/need the json or .ll files to be created.

