### PR TITLE
Refactor: lift IR to llvm Value for block metadata; add BlockIR

### DIFF
--- a/src/Analysis/HappensBeforeGraph.cpp
+++ b/src/Analysis/HappensBeforeGraph.cpp
@@ -131,13 +131,13 @@ const ForkEvent *getCorrespondingFork(const JoinEvent *join, const ProgramTrace 
   for (auto it = forks.rbegin(), rend = forks.rend(); it != rend; ++it) {
     auto const fork = *it;
     if (fork->getID() < join->getID()) {
-      llvm::errs() << "Using nearest fork heuristic to find corresponding fork!\n\tJoin: " << *join->getInst()
-                   << "\n\tFork: " << *fork->getInst() << "\n";
+      llvm::errs() << "Using nearest fork heuristic to find corresponding fork!\n\tJoin: " << *join->getLLVMRepr()
+                   << "\n\tFork: " << *fork->getLLVMRepr() << "\n";
       return fork;
     }
   }
 
-  llvm::errs() << "Unable to find corresponding fork for join event: " << *join->getInst() << "\n";
+  llvm::errs() << "Unable to find corresponding fork for join event: " << *join->getLLVMRepr() << "\n";
   return nullptr;
 }
 
@@ -164,9 +164,9 @@ HappensBeforeGraph::HappensBeforeGraph(const race::ProgramTrace &program) {
   // the dual-edge is added between the prev event and the current event,
   // and the current event is added to the map so that the next event to reach
   // this barrier will add the dual-edge with the curent event.
-  std::map<const llvm::Instruction *, const BarrierEvent *> lastBarrier;
+  std::map<const llvm::Value *, const BarrierEvent *> lastBarrier;
   auto addBarrierEdge = [&lastBarrier, this](const BarrierEvent *event) {
-    auto const barrierInst = event->getInst();
+    auto const barrierInst = event->getLLVMRepr();
 
     auto it = lastBarrier.find(barrierInst);
     if (it != lastBarrier.end()) {

--- a/src/Analysis/OpenMPAnalysis.h
+++ b/src/Analysis/OpenMPAnalysis.h
@@ -41,7 +41,7 @@ class ReduceAnalysis {
 
  public:
   // return true if inst is inside of code blocks making up belonging to reduce
-  bool reduceContains(const llvm::Instruction* reduce, const llvm::Instruction* inst) const;
+  bool reduceContains(const ReduceInst reduce, const ReduceInst inst) const;
 };
 
 class OpenMPAnalysis {

--- a/src/IR/IR.cpp
+++ b/src/IR/IR.cpp
@@ -59,13 +59,13 @@ llvm::raw_ostream &race::operator<<(llvm::raw_ostream &os, const IR::Type &type)
 void ReadIR::print(llvm::raw_ostream &os) const {
   auto val = getAccessedValue();
   auto valName = getValNameHelper(val);
-  os << "IR " << type << " - " << valName << " - " << getInst() << "\n";
+  os << "IR " << type << " - " << valName << " - " << getLLVMRepr() << "\n";
 }
 
 void WriteIR::print(llvm::raw_ostream &os) const {
   auto val = getAccessedValue();
   auto valName = getValNameHelper(val);
-  os << "IR " << type << " - " << valName << " - " << getInst() << "\n";
+  os << "IR " << type << " - " << valName << " - " << getLLVMRepr() << "\n";
 }
 
 void ForkIR::print(llvm::raw_ostream &os) const {
@@ -84,7 +84,7 @@ void JoinIR::print(llvm::raw_ostream &os) const {
 }
 
 void CallIR::print(llvm::raw_ostream &os) const {
-  auto func = llvm::cast<llvm::CallBase>(getInst())->getFunction();
+  auto func = llvm::cast<llvm::CallBase>(getLLVMRepr())->getFunction();
   auto funcName = getValNameHelper(func, "UnknownFunc");
   os << "IR " << type << " - " << funcName << "\n";
 }
@@ -106,4 +106,9 @@ llvm::StringRef IR::toString() const {
   print(os);
   os.str();
   return llvm::StringRef(s);
+}
+
+void BlockIR::print(llvm::raw_ostream &os) const {
+  auto blockName = getValNameHelper(this->getLLVMRepr(), "UnnamedBlock");
+  os << "IR " << type << " - " << blockName << "\n";
 }

--- a/src/IR/IR.h
+++ b/src/IR/IR.h
@@ -216,7 +216,7 @@ class BlockIR : public IR {
   [[nodiscard]] inline const llvm::BasicBlock *getLLVMRepr() const override { return block; }
 
   // Used for llvm style RTTI (isa, dyn_cast, etc.)
-  static bool classof(const IR *e) { return e->type >= Type::Call && e->type < Type::END_Call; }
+  static bool classof(const IR *e) { return e->type >= Type::Block && e->type < Type::END_Block; }
 };
 
 // CallIR is one of the classes in IR.h that can be concrete.

--- a/src/IR/IR.h
+++ b/src/IR/IR.h
@@ -56,9 +56,11 @@ class IR {
     OpenMPSingleStart,
     OpenMPSingleEnd,
     OpenMPReduce,
-    END_Call
+    END_Call,
+    Block,
+    END_Block,
   } type;
-  [[nodiscard]] virtual const llvm::Instruction *getInst() const = 0;
+  [[nodiscard]] virtual const llvm::Value *getLLVMRepr() const = 0;
 
   [[nodiscard]] virtual llvm::StringRef toString() const;
   virtual void print(llvm::raw_ostream &os) const = 0;
@@ -76,12 +78,20 @@ class IR {
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const IR &stmt);
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const IR::Type &type);
 
+class InstIR : public IR {
+ protected:
+  using IR::IR;
+
+ public:
+  [[nodiscard]] const llvm::Instruction *getLLVMRepr() const override = 0;
+};
+
 // Dont Overload This class
 // This is a convenience interface so that read/write can be kept in list
 // together
-class MemAccessIR : public IR {
+class MemAccessIR : public InstIR {
  protected:
-  using IR::IR;
+  using InstIR::InstIR;
 
  public:
   [[nodiscard]] virtual const llvm::Value *getAccessedValue() const = 0;
@@ -90,7 +100,7 @@ class MemAccessIR : public IR {
   static inline bool classof(const IR *e) { return e->type >= Type::Read && e->type <= Type::END_Write; }
 
  protected:
-  explicit MemAccessIR(Type t) : IR(t) {
+  explicit MemAccessIR(Type t) : InstIR(t) {
     assert(t >= Type::Read && t <= Type::END_Write && "MemAccess constructed with non read/write type!");
   }
 };
@@ -117,9 +127,9 @@ class WriteIR : public MemAccessIR {
   static inline bool classof(const IR *e) { return e->type >= Type::Write && e->type < Type::END_Write; }
 };
 
-class ForkIR : public IR {
+class ForkIR : public InstIR {
  protected:
-  using IR::IR;
+  using InstIR::InstIR;
 
  public:
   // Get the handle for the thread being spawned.
@@ -138,9 +148,9 @@ class ForkIR : public IR {
   static bool classof(const IR *e) { return e->type >= Type::Fork && e->type < Type::END_Fork; }
 };
 
-class JoinIR : public IR {
+class JoinIR : public InstIR {
  protected:
-  using IR::IR;
+  using InstIR::InstIR;
 
  public:
   // Get the handle for the thread being joined.
@@ -154,9 +164,9 @@ class JoinIR : public IR {
   static bool classof(const IR *e) { return e->type >= Type::Join && e->type < Type::END_Join; }
 };
 
-class LockIR : public IR {
+class LockIR : public InstIR {
  protected:
-  using IR::IR;
+  using InstIR::InstIR;
 
  public:
   [[nodiscard]] virtual const llvm::Value *getLockValue() const = 0;
@@ -167,9 +177,9 @@ class LockIR : public IR {
   static bool classof(const IR *e) { return e->type >= Type::Lock && e->type < Type::END_Lock; }
 };
 
-class UnlockIR : public IR {
+class UnlockIR : public InstIR {
  protected:
-  using IR::IR;
+  using InstIR::InstIR;
 
  public:
   [[nodiscard]] virtual const llvm::Value *getLockValue() const = 0;
@@ -180,9 +190,9 @@ class UnlockIR : public IR {
   static bool classof(const IR *e) { return e->type >= Type::Unlock && e->type < Type::END_Unlock; }
 };
 
-class BarrierIR : public IR {
+class BarrierIR : public InstIR {
  protected:
-  using IR::IR;
+  using InstIR::InstIR;
 
  public:
   void print(llvm::raw_ostream &os) const override;
@@ -191,23 +201,41 @@ class BarrierIR : public IR {
   static bool classof(const IR *e) { return e->type >= Type::Barrier && e->type < Type::END_Barrier; }
 };
 
-// CallIR is the only class in IR.h that can be concrete.
+// BlockIR denotes metadata associated with a particular block which is not captured by LLVM at the instruction level.
+// Instead, this denotes information about a given block which needs to be provided at IR-time.
+class BlockIR : public IR {
+  const llvm::BasicBlock *block;
+
+ protected:
+  // Constructor for sub types
+  BlockIR(const llvm::BasicBlock *block, Type ty) : IR(ty), block(block) { assert(ty >= Type::Block && ty < Type::END_Block); }
+
+ public:
+  void print(llvm::raw_ostream &os) const override;
+
+  [[nodiscard]] inline const llvm::BasicBlock *getLLVMRepr() const override { return block; }
+
+  // Used for llvm style RTTI (isa, dyn_cast, etc.)
+  static bool classof(const IR *e) { return e->type >= Type::Call && e->type < Type::END_Call; }
+};
+
+// CallIR is one of the classes in IR.h that can be concrete.
 // Most function calls should use CallIR's public constructor.
 // In some special cases, we want to note calls to specifc functions, such as omp_for_init.
 // In these rare special cases there can be sub-types that inherit from CallIR and use the protected constructor.
-class CallIR : public IR {
+class CallIR : public InstIR {
   const llvm::CallBase *inst;
 
  protected:
   // Constructor for sub types
-  CallIR(const llvm::CallBase *inst, Type ty) : IR(ty), inst(inst) { assert(ty >= Type::Call && ty < Type::END_Call); }
+  CallIR(const llvm::CallBase *inst, Type ty) : InstIR(ty), inst(inst) { assert(ty >= Type::Call && ty < Type::END_Call); }
 
  public:
-  explicit CallIR(const llvm::CallBase *inst) : IR(Type::Call), inst(inst) {}
+  explicit CallIR(const llvm::CallBase *inst) : InstIR(Type::Call), inst(inst) {}
 
   void print(llvm::raw_ostream &os) const override;
 
-  [[nodiscard]] inline const llvm::CallBase *getInst() const override { return inst; }
+  [[nodiscard]] inline const llvm::CallBase *getLLVMRepr() const override { return inst; }
 
   [[nodiscard]] inline bool isIndirect() const { return inst->isIndirectCall(); }
 

--- a/src/IR/IRImpls.h
+++ b/src/IR/IRImpls.h
@@ -27,7 +27,7 @@ class Load : public ReadIR {
  public:
   explicit Load(const llvm::LoadInst *load) : ReadIR(Type::Load), inst(load) {}
 
-  [[nodiscard]] inline const llvm::LoadInst *getInst() const override { return inst; }
+  [[nodiscard]] inline const llvm::LoadInst *getLLVMRepr() const override { return inst; }
 
   [[nodiscard]] inline const llvm::Value *getAccessedValue() const override { return inst->getPointerOperand(); }
 
@@ -46,7 +46,7 @@ class APIRead : public ReadIR {
   APIRead(const llvm::CallBase *inst, unsigned int operandOffset)
       : ReadIR(Type::APIRead), operandOffset(operandOffset), inst(inst) {}
 
-  [[nodiscard]] inline const llvm::CallBase *getInst() const override { return inst; }
+  [[nodiscard]] inline const llvm::CallBase *getLLVMRepr() const override { return inst; }
 
   [[nodiscard]] inline const llvm::Value *getAccessedValue() const override { return inst->getOperand(operandOffset); }
 
@@ -64,7 +64,7 @@ class Store : public WriteIR {
  public:
   explicit Store(const llvm::StoreInst *store) : WriteIR(Type::Store), inst(store) {}
 
-  [[nodiscard]] inline const llvm::StoreInst *getInst() const override { return inst; }
+  [[nodiscard]] inline const llvm::StoreInst *getLLVMRepr() const override { return inst; }
 
   [[nodiscard]] inline const llvm::Value *getAccessedValue() const override { return inst->getPointerOperand(); }
 
@@ -83,10 +83,10 @@ class APIWrite : public WriteIR {
   APIWrite(const llvm::CallBase *inst, unsigned int operandOffset)
       : WriteIR(Type::APIWrite), operandOffset(operandOffset), inst(inst) {}
 
-  [[nodiscard]] inline const llvm::CallBase *getInst() const override { return inst; }
+  [[nodiscard]] inline const llvm::CallBase *getLLVMRepr() const override { return inst; }
 
   [[nodiscard]] inline const llvm::Value *getAccessedValue() const override {
-    return getInst()->getOperand(operandOffset);
+    return getLLVMRepr()->getOperand(operandOffset);
   }
 
   // Used for llvm style RTTI (isa, dyn_cast, etc.)
@@ -105,7 +105,7 @@ class PthreadCreate : public ForkIR {
  public:
   explicit PthreadCreate(const llvm::CallBase *inst) : ForkIR(Type::PthreadCreate), inst(inst) {}
 
-  [[nodiscard]] inline const llvm::CallBase *getInst() const override { return inst; }
+  [[nodiscard]] inline const llvm::CallBase *getLLVMRepr() const override { return inst; }
 
   [[nodiscard]] const llvm::Value *getThreadHandle() const override {
     return inst->getArgOperand(threadHandleOffset)->stripPointerCasts();
@@ -133,7 +133,7 @@ class OpenMPFork : public ForkIR {
  public:
   explicit OpenMPFork(const llvm::CallBase *inst) : ForkIR(Type::OpenMPFork), inst(inst) {}
 
-  [[nodiscard]] inline const llvm::CallBase *getInst() const override { return inst; }
+  [[nodiscard]] inline const llvm::CallBase *getLLVMRepr() const override { return inst; }
 
   [[nodiscard]] const llvm::Value *getThreadHandle() const override {
     return inst->getArgOperand(threadHandleOffset)->stripPointerCasts();
@@ -158,7 +158,7 @@ class PthreadJoin : public JoinIR {
  public:
   explicit PthreadJoin(const llvm::CallBase *inst) : JoinIR(Type::PthreadJoin), inst(inst) {}
 
-  [[nodiscard]] inline const llvm::CallBase *getInst() const override { return inst; }
+  [[nodiscard]] inline const llvm::CallBase *getLLVMRepr() const override { return inst; }
 
   [[nodiscard]] const llvm::Value *getThreadHandle() const override {
     return inst->getArgOperand(threadHandleOffset)->stripPointerCasts();
@@ -175,7 +175,7 @@ class OpenMPJoin : public JoinIR {
  public:
   explicit OpenMPJoin(const std::shared_ptr<OpenMPFork> fork) : JoinIR(Type::OpenMPJoin), fork(fork) {}
 
-  [[nodiscard]] inline const llvm::CallBase *getInst() const override { return fork->getInst(); }
+  [[nodiscard]] inline const llvm::CallBase *getLLVMRepr() const override { return fork->getLLVMRepr(); }
 
   [[nodiscard]] const llvm::Value *getThreadHandle() const override { return fork->getThreadHandle(); }
 
@@ -197,7 +197,7 @@ class LockIRImpl : public LockIR {
  public:
   explicit LockIRImpl(const llvm::CallBase *call) : LockIR(T), inst(call) {}
 
-  [[nodiscard]] inline const llvm::CallBase *getInst() const override { return inst; }
+  [[nodiscard]] inline const llvm::CallBase *getLLVMRepr() const override { return inst; }
 
   [[nodiscard]] const llvm::Value *getLockValue() const override {
     return inst->getArgOperand(lockObjectOffset)->stripPointerCasts();
@@ -219,7 +219,7 @@ class OpenMPCriticalStart: public LockIR {
  public:
   explicit OpenMPCriticalStart(const llvm::CallBase *call) : LockIR(Type::OpenMPCriticalStart), inst(call) {}
 
-  [[nodiscard]] inline const llvm::CallBase *getInst() const override { return inst; }
+  [[nodiscard]] inline const llvm::CallBase *getLLVMRepr() const override { return inst; }
 
   [[nodiscard]] const llvm::Value *getLockValue() const override {
     return inst->getArgOperand(identityOffset)->stripPointerCasts();
@@ -247,7 +247,7 @@ class UnlockIRImpl : public UnlockIR {
  public:
   explicit UnlockIRImpl(const llvm::CallBase *call) : UnlockIR(T), inst(call) {}
 
-  [[nodiscard]] inline const llvm::CallBase *getInst() const override { return inst; }
+  [[nodiscard]] inline const llvm::CallBase *getLLVMRepr() const override { return inst; }
 
   [[nodiscard]] const llvm::Value *getLockValue() const override {
     return inst->getArgOperand(lockObjectOffset)->stripPointerCasts();
@@ -269,7 +269,7 @@ class OpenMPCriticalEnd : public UnlockIR {
  public:
   explicit OpenMPCriticalEnd(const llvm::CallBase *call) : UnlockIR(Type::OpenMPCriticalEnd), inst(call) {}
 
-  [[nodiscard]] inline const llvm::CallBase *getInst() const override { return inst; }
+  [[nodiscard]] inline const llvm::CallBase *getLLVMRepr() const override { return inst; }
 
   [[nodiscard]] const llvm::Value *getLockValue() const override {
     return inst->getArgOperand(identityOffset)->stripPointerCasts();
@@ -294,7 +294,7 @@ class OpenMPBarrier : public BarrierIR {
  public:
   explicit OpenMPBarrier(const llvm::CallBase *call) : BarrierIR(Type::OpenMPBarrier), inst(call) {}
 
-  [[nodiscard]] inline const llvm::CallBase *getInst() const override { return inst; }
+  [[nodiscard]] inline const llvm::CallBase *getLLVMRepr() const override { return inst; }
 };
 
 // =================================================================

--- a/src/LanguageModel/RaceModel.cpp
+++ b/src/LanguageModel/RaceModel.cpp
@@ -19,7 +19,7 @@ using namespace pta;
 
 RaceModel::RaceModel(llvm::Module *M, llvm::StringRef entry) : Super(M, entry) {
   ctx::setOriginRules(
-      [&](const ctx *context, const llvm::Instruction *I) -> bool { return this->isInvokingAnOrigin(context, I); });
+      [&](const ctx *context, const llvm::Value *V) -> bool { return this->isInvokingAnOrigin(context, V); });
 }
 
 InterceptResult RaceModel::interceptFunction(const ctx *callerCtx, const ctx *calleeCtx, const llvm::Function *F,
@@ -115,8 +115,8 @@ namespace {
 const std::set<llvm::StringRef> origins{"pthread_create", "__kmpc_fork_call"};
 }  // namespace
 
-bool RaceModel::isInvokingAnOrigin(const ctx *prevCtx, const llvm::Instruction *I) {
-  auto call = llvm::dyn_cast<CallBase>(I);
+bool RaceModel::isInvokingAnOrigin(const ctx *prevCtx, const llvm::Value *V) {
+  auto call = llvm::dyn_cast<CallBase>(V);
   if (!call || !call->getCalledFunction() || !call->getCalledFunction()->hasName()) return false;
 
   auto const name = call->getCalledFunction()->getName();

--- a/src/LanguageModel/RaceModel.h
+++ b/src/LanguageModel/RaceModel.h
@@ -27,7 +27,7 @@ using PtsTy = BitVectorPTS;
 class RaceModel : public LangModelBase<ctx, MemModel, PtsTy, RaceModel> {
   using Super = LangModelBase<ctx, MemModel, PtsTy, RaceModel>;
 
-  bool isInvokingAnOrigin(const ctx *prevCtx, const llvm::Instruction *I);
+  bool isInvokingAnOrigin(const ctx *prevCtx, const llvm::Value *V);
 
  public:
   // determine whether the resolved indirect call is compatible

--- a/src/Trace/Event.cpp
+++ b/src/Trace/Event.cpp
@@ -14,7 +14,7 @@ limitations under the License.
 using namespace race;
 
 llvm::raw_ostream &race::operator<<(llvm::raw_ostream &os, const Event &event) {
-  os << event.getID() << " " << event.type << "\t" << *event.getInst();
+  os << event.getID() << " " << event.type << "\t" << *event.getLLVMRepr();
   return os;
 }
 

--- a/src/Trace/EventImpl.cpp
+++ b/src/Trace/EventImpl.cpp
@@ -31,13 +31,13 @@ std::vector<const pta::ObjTy *> WriteEventImpl::getAccessedMemory() const {
 std::vector<const pta::CallGraphNodeTy *> ForkEventImpl::getThreadEntry() const {
   auto entryVal = fork->getThreadEntry();
   if (auto entryFunc = llvm::dyn_cast<llvm::Function>(entryVal)) {
-    auto const newContext = pta::CT::contextEvolve(info->context, fork->getInst());
+    auto const newContext = pta::CT::contextEvolve(info->context, fork->getLLVMRepr());
     auto const entryNode = info->thread.program.pta.getDirectNodeOrNull(newContext, entryFunc);
     return {entryNode};
   }
 
   // the entry is indirect and we need to figure out where the real function is
-  auto callsite = info->thread.program.pta.getInDirectCallSite(info->context, fork->getInst());
+  auto callsite = info->thread.program.pta.getInDirectCallSite(info->context, fork->getLLVMRepr());
   auto const &nodes = callsite->getResolvedNode();
   return std::vector<const pta::CallGraphNodeTy *>(nodes.begin(), nodes.end());
 }

--- a/src/Trace/EventImpl.h
+++ b/src/Trace/EventImpl.h
@@ -186,7 +186,7 @@ class EnterCallEventImpl : public EnterCallEvent {
   [[nodiscard]] inline const race::CallIR *getIRInst() const override { return call.get(); }
 
   [[nodiscard]] const llvm::Function *getCalledFunction() const override {
-    return call->getInst()->getCalledFunction();
+    return call->getLLVMRepr()->getCalledFunction();
   }
 };
 
@@ -206,7 +206,7 @@ class LeaveCallEventImpl : public LeaveCallEvent {
   [[nodiscard]] inline const race::CallIR *getIRInst() const override { return call.get(); }
 
   [[nodiscard]] const llvm::Function *getCalledFunction() const override {
-    return call->getInst()->getCalledFunction();
+    return call->getLLVMRepr()->getCalledFunction();
   }
 };
 
@@ -226,7 +226,7 @@ class ExternCallEventImpl : public ExternCallEvent {
   [[nodiscard]] inline const race::CallIR *getIRInst() const override { return call.get(); }
 
   [[nodiscard]] const llvm::Function *getCalledFunction() const override {
-    return call->getInst()->getCalledFunction();
+    return call->getLLVMRepr()->getCalledFunction();
   }
 };
 

--- a/src/Trace/ThreadTrace.cpp
+++ b/src/Trace/ThreadTrace.cpp
@@ -64,12 +64,12 @@ void traverseCallNode(const pta::CallGraphNodeTy *node, const ThreadTrace &threa
         continue;
       }
 
-      auto directContext = pta::CT::contextEvolve(context, ir->getInst());
-      auto const directNode = pta.getDirectNodeOrNull(directContext, call->getInst()->getCalledFunction());
+      auto directContext = pta::CT::contextEvolve(context, call->getLLVMRepr());
+      auto const directNode = pta.getDirectNodeOrNull(directContext, call->getLLVMRepr()->getCalledFunction());
 
       if (directNode == nullptr) {
         // TODO: LOG unable to get child node
-        llvm::errs() << "Unable to get child node: " << call->getInst()->getCalledFunction()->getName() << "\n";
+        llvm::errs() << "Unable to get child node: " << call->getLLVMRepr()->getCalledFunction()->getName() << "\n";
         continue;
       }
 

--- a/tests/unit/IR/IR.test.cpp
+++ b/tests/unit/IR/IR.test.cpp
@@ -37,8 +37,8 @@ TEST_CASE("Manually Constructed IR", "[unit][IR]") {
     auto loadInst = IRB.CreateLoad(IRB.getInt32Ty(), alloca);
 
     auto load = std::make_unique<race::Load>(loadInst);
-    REQUIRE(load->getInst() == loadInst);
-    REQUIRE(llvm::isa<llvm::LoadInst>(load->getInst()));
+    REQUIRE(load->getLLVMRepr() == loadInst);
+    REQUIRE(llvm::isa<llvm::LoadInst>(load->getLLVMRepr()));
     REQUIRE(load->getAccessedValue() == loadInst->getPointerOperand());
     REQUIRE(llvm::isa<race::ReadIR>(load));
     REQUIRE(llvm::isa<race::MemAccessIR>(load));
@@ -50,8 +50,8 @@ TEST_CASE("Manually Constructed IR", "[unit][IR]") {
     auto storeInst = IRB.CreateStore(val, alloca);
 
     auto store = std::make_unique<race::Store>(storeInst);
-    REQUIRE(store->getInst() == storeInst);
-    REQUIRE(llvm::isa<llvm::StoreInst>(store->getInst()));
+    REQUIRE(store->getLLVMRepr() == storeInst);
+    REQUIRE(llvm::isa<llvm::StoreInst>(store->getLLVMRepr()));
     REQUIRE(store->getAccessedValue() == storeInst->getPointerOperand());
     REQUIRE(llvm::isa<race::WriteIR>(store));
     REQUIRE(llvm::isa<race::MemAccessIR>(store));
@@ -62,8 +62,8 @@ TEST_CASE("Manually Constructed IR", "[unit][IR]") {
     REQUIRE(callInst != nullptr);
 
     auto call = std::make_unique<race::CallIR>(callInst);
-    REQUIRE(call->getInst() == callInst);
-    REQUIRE(llvm::isa<llvm::CallBase>(call->getInst()));
+    REQUIRE(call->getLLVMRepr() == callInst);
+    REQUIRE(llvm::isa<llvm::CallBase>(call->getLLVMRepr()));
     REQUIRE(llvm::isa<race::CallIR>(call));
   }
 }
@@ -101,7 +101,7 @@ define void @foo(i32* %x) {
 
   auto externcall = llvm::dyn_cast<race::CallIR>(racefunc.at(1).get());
   REQUIRE(externcall);
-  REQUIRE(externcall->getInst()->getCalledFunction()->getName() == "bar");
+  REQUIRE(externcall->getLLVMRepr()->getCalledFunction()->getName() == "bar");
 
   auto write = llvm::dyn_cast<race::WriteIR>(racefunc.at(2).get());
   REQUIRE(write);
@@ -109,7 +109,7 @@ define void @foo(i32* %x) {
 
   auto call = llvm::dyn_cast<race::CallIR>(racefunc.at(3).get());
   REQUIRE(call);
-  REQUIRE(call->getInst()->getCalledFunction()->getName() == "hello");
+  REQUIRE(call->getLLVMRepr()->getCalledFunction()->getName() == "hello");
 }
 
 TEST_CASE("Builder pthread create/join", "[unit][IR]") {

--- a/tests/unit/IR/OpenMPIR.test.cpp
+++ b/tests/unit/IR/OpenMPIR.test.cpp
@@ -65,21 +65,21 @@ declare void @__kmpc_fork_call(%struct.ident_t*, i32, void (i32*, i32*, ...)*, .
 
   auto ompFork = llvm::dyn_cast<race::OpenMPFork>(racefunc.at(0).get());
   REQUIRE(ompFork);
-  CHECK(ompFork->getInst()->getCalledFunction()->getName() == "__kmpc_fork_call");
+  CHECK(ompFork->getLLVMRepr()->getCalledFunction()->getName() == "__kmpc_fork_call");
   CHECK(ompFork->getThreadEntry()->getName() == ".omp_outlined.");
 
   ompFork = llvm::dyn_cast<race::OpenMPFork>(racefunc.at(1).get());
   REQUIRE(ompFork);
-  CHECK(ompFork->getInst()->getCalledFunction()->getName() == "__kmpc_fork_call");
+  CHECK(ompFork->getLLVMRepr()->getCalledFunction()->getName() == "__kmpc_fork_call");
   CHECK(ompFork->getThreadEntry()->getName() == ".omp_outlined.");
 
   auto ompJoin = llvm::dyn_cast<race::OpenMPJoin>(racefunc.at(2).get());
   REQUIRE(ompJoin);
-  CHECK(ompJoin->getInst()->getCalledFunction()->getName() == "__kmpc_fork_call");
+  CHECK(ompJoin->getLLVMRepr()->getCalledFunction()->getName() == "__kmpc_fork_call");
 
   ompJoin = llvm::dyn_cast<race::OpenMPJoin>(racefunc.at(3).get());
   REQUIRE(ompJoin);
-  CHECK(ompJoin->getInst()->getCalledFunction()->getName() == "__kmpc_fork_call");
+  CHECK(ompJoin->getLLVMRepr()->getCalledFunction()->getName() == "__kmpc_fork_call");
 }
 
 TEST_CASE("Build OpenMP once/end_once IR") {

--- a/website/docs/doc-adding-new-features.md
+++ b/website/docs/doc-adding-new-features.md
@@ -38,7 +38,7 @@ class PthreadCreateInfo : public ForkInfo {
 public:
     explicit PthreadCreateInfo(const llvm::CallBase *inst) : inst(inst) {}
 
-    [[nodiscard]] inline const llvm::CallBase *getInst() const override { return inst; }
+    [[nodiscard]] inline const llvm::CallBase *getLLVMRepr() const override { return inst; }
 
     [[nodiscard]] const llvm::Value *getThreadHandle() const override {
         return inst->getArgOperand(threadHandleOffset)->stripPointerCasts();

--- a/website/docs/doc-overview.md
+++ b/website/docs/doc-overview.md
@@ -154,7 +154,7 @@ So, the interface for a logical read operation looks something like the followin
 ```cpp
 class Read {
 public:
-    virtual const llvm::Inst* getInst() const =  0;
+    virtual const llvm::Instruction* getLLVMRepr() const = 0;
     virtual const llvm::Value *getReadValue() const = 0;
 };
 ```
@@ -167,14 +167,14 @@ Now to treat different types of llvm instructions as reads, we just need to defi
 class Load : public Read {
     const LoadInst *load;
 public:
-    const llvm::LoadInst* getInst() const override { return load; }
+    const llvm::LoadInst* getLLVMRepr() const override { return load; }
     const llvm::Value *getReadValue() const override { return load->getPointerOperand(); }
 };
 
 class MemCpyRead : public Read {
     const CallBase *inst;
 public:
-    const llvm::LoaCallBasedInst* getInst() const override { return inst; }
+    const llvm::LoadCallBasedInst* getLLVMRepr() const override { return inst; }
 
     // Assuming 3rd operand is the value being read. This is a fake example
     const llvm::Value *getReadValue() const override { return load->getOperand(3); }


### PR DESCRIPTION
Changes IR's getInst to getLLVMRepr and changes the return value from Instruction to Value to enable the creation of pseudo-IR to insert metadata as IR instructions.

Also introduces a new virtual IR, BlockIR, which demonstrates the need for the above change. This BlockIR is used to denote the beginning and ends of basic blocks which hold metadata, such as those necessary for #114.