### PR TITLE
Correct minor misleading comment

### DIFF
--- a/src/Analysis/OpenMPAnalysis.h
+++ b/src/Analysis/OpenMPAnalysis.h
@@ -82,8 +82,8 @@ class OpenMPAnalysis {
   // we do not distinguise between reduce and reduce_nowait
   bool inSameReduce(const Event* event1, const Event* event2) const;
 
-  // return true if both events are inside of the same master region
-  // similar with single; only one thread executes
+  // return true if both events are inside any master region of the same team
+  // similar with single; only one thread executes, but for master, a specific thread executes
   bool bothInMasterBlock(const Event* event1, const Event* event2) const;
 };
 


### PR DESCRIPTION
This comment is misleading and is not accurate to the actual behaviour of the method; it is outdated.