### PR TITLE
Replace ifndef header guards with pragma once

### DIFF
--- a/src/Demangler/Demangler.h
+++ b/src/Demangler/Demangler.h
@@ -9,8 +9,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#ifndef PTA_DEMANGLER_H
-#define PTA_DEMANGLER_H
+#pragma once
 
 #include <llvm/ADT/StringRef.h>
 #include <llvm/Demangle/Demangle.h>
@@ -56,5 +55,3 @@ struct Demangler : public llvm::ItaniumPartialDemangler {
 };
 
 }  // namespace pta
-
-#endif

--- a/src/PointerAnalysis/Context/CtxTrait.h
+++ b/src/PointerAnalysis/Context/CtxTrait.h
@@ -12,8 +12,7 @@ limitations under the License.
 //
 // Created by peiming on 8/14/19.
 //
-#ifndef PTA_CTXTRAIT_H
-#define PTA_CTXTRAIT_H
+#pragma once
 
 namespace pta {
 
@@ -23,5 +22,3 @@ class CtxTrait {
 };
 
 }  // namespace pta
-
-#endif

--- a/src/PointerAnalysis/Context/HybridCtx.h
+++ b/src/PointerAnalysis/Context/HybridCtx.h
@@ -12,8 +12,7 @@ limitations under the License.
 //
 // Created by peiming on 4/2/20.
 //
-#ifndef PTA_HYBRIDCTX_H
-#define PTA_HYBRIDCTX_H
+#pragma once
 
 #include <llvm/ADT/STLExtras.h>
 
@@ -110,4 +109,3 @@ struct hash<pta::HybridCtx<Args...>> {
 };
 
 }  // namespace std
-#endif

--- a/src/PointerAnalysis/Context/KCallSite.h
+++ b/src/PointerAnalysis/Context/KCallSite.h
@@ -12,8 +12,7 @@ limitations under the License.
 //
 // Created by peiming on 11/19/19.
 //
-#ifndef PTA_KCALLSITE_H
-#define PTA_KCALLSITE_H
+#pragma once
 
 #include <llvm/ADT/Hashing.h>
 #include <llvm/Support/raw_ostream.h>
@@ -148,5 +147,3 @@ struct hash<pta::KCallSite<K>> {
 };
 
 }  // namespace std
-
-#endif

--- a/src/PointerAnalysis/Context/KOrigin.h
+++ b/src/PointerAnalysis/Context/KOrigin.h
@@ -13,8 +13,7 @@ limitations under the License.
 // Created by peiming on 11/19/19.
 //
 
-#ifndef PTA_KORIGIN_H
-#define PTA_KORIGIN_H
+#pragma once
 
 #include <llvm/ADT/StringSet.h>
 
@@ -118,5 +117,3 @@ struct hash<pta::KOrigin<K, L>> {
 };
 
 }  // namespace std
-
-#endif

--- a/src/PointerAnalysis/Context/NoCtx.h
+++ b/src/PointerAnalysis/Context/NoCtx.h
@@ -12,8 +12,7 @@ limitations under the License.
 //
 // Created by peiming on 11/19/19.
 //
-#ifndef PTA_NOCTX_H
-#define PTA_NOCTX_H
+#pragma once
 
 #include <string>
 
@@ -41,5 +40,3 @@ struct CtxTrait<NoCtx> {
 };
 
 }  // namespace pta
-
-#endif

--- a/src/PointerAnalysis/Context/PtrRingBuffer.h
+++ b/src/PointerAnalysis/Context/PtrRingBuffer.h
@@ -13,8 +13,7 @@ limitations under the License.
 // Created by peiming on 11/19/19.
 //
 
-#ifndef PTA_PTRRINGBUFFER_H
-#define PTA_PTRRINGBUFFER_H
+#pragma once
 
 namespace pta {
 
@@ -101,5 +100,3 @@ class PtrRingBuffer {
 };
 
 }  // namespace pta
-
-#endif

--- a/src/PointerAnalysis/Graph/CallGraph.h
+++ b/src/PointerAnalysis/Graph/CallGraph.h
@@ -12,8 +12,7 @@ limitations under the License.
 //
 // Created by peiming on 8/14/19.
 //
-#ifndef PTA_CALLGRAPH_H
-#define PTA_CALLGRAPH_H
+#pragma once
 
 #include <llvm/ADT/GraphTraits.h>
 #include <llvm/Support/DOTGraphTraits.h>
@@ -181,5 +180,3 @@ struct DOTGraphTraits<const pta::CallGraph<ctx>> : public DefaultDOTGraphTraits 
 };
 
 }  // namespace llvm
-
-#endif

--- a/src/PointerAnalysis/Graph/ConstraintGraph/CGNodeBase.h
+++ b/src/PointerAnalysis/Graph/ConstraintGraph/CGNodeBase.h
@@ -12,8 +12,7 @@ limitations under the License.
 //
 // Created by peiming on 11/1/19.
 //
-#ifndef PTA_CGNODEBASE_H
-#define PTA_CGNODEBASE_H
+#pragma once
 #include <llvm/ADT/SparseBitVector.h>
 #include <llvm/Demangle/Demangle.h>
 #include <llvm/IR/DebugInfoMetadata.h>
@@ -386,5 +385,3 @@ class CGNodeBase {
 };
 
 }  // namespace pta
-
-#endif

--- a/src/PointerAnalysis/Graph/ConstraintGraph/CGObjNode.h
+++ b/src/PointerAnalysis/Graph/ConstraintGraph/CGObjNode.h
@@ -12,8 +12,7 @@ limitations under the License.
 //
 // Created by peiming on 11/2/19.
 //
-#ifndef PTA_CGOBJNODE_H
-#define PTA_CGOBJNODE_H
+#pragma once
 
 #include "CGNodeBase.h"
 
@@ -73,5 +72,3 @@ class CGObjNode : public CGNodeBase<ctx> {
 };
 
 }  // namespace pta
-
-#endif

--- a/src/PointerAnalysis/Graph/ConstraintGraph/CGPtrNode.h
+++ b/src/PointerAnalysis/Graph/ConstraintGraph/CGPtrNode.h
@@ -12,8 +12,7 @@ limitations under the License.
 //
 // Created by peiming on 11/2/19.
 //
-#ifndef PTA_CGPTRNODE_H
-#define PTA_CGPTRNODE_H
+#pragma once
 
 #include <llvm/IR/GlobalValue.h>
 
@@ -109,5 +108,3 @@ class CGPtrNode : public CGNodeBase<ctx> {
 };
 
 }  // namespace pta
-
-#endif

--- a/src/PointerAnalysis/Graph/ConstraintGraph/CGSuperNode.h
+++ b/src/PointerAnalysis/Graph/ConstraintGraph/CGSuperNode.h
@@ -12,8 +12,7 @@ limitations under the License.
 //
 // Created by peiming on 11/2/19.
 //
-#ifndef PTA_CGSUPERNODE_H
-#define PTA_CGSUPERNODE_H
+#pragma once
 
 // TODO: maybe merge SCC later?
 
@@ -83,5 +82,3 @@ class CGSuperNode : public CGNodeBase<ctx> {
 };
 
 }  // namespace pta
-
-#endif

--- a/src/PointerAnalysis/Graph/ConstraintGraph/ConstraintGraph.h
+++ b/src/PointerAnalysis/Graph/ConstraintGraph/ConstraintGraph.h
@@ -12,8 +12,7 @@ limitations under the License.
 //
 // Created by peiming on 8/26/19.
 //
-#ifndef PTA_CONSTRAINTGRAPH_H
-#define PTA_CONSTRAINTGRAPH_H
+#pragma once
 
 #include "CGObjNode.h"
 #include "CGPtrNode.h"
@@ -241,5 +240,3 @@ struct DOTGraphTraits<const pta::ConstraintGraph<ctx>> : public DefaultDOTGraphT
 }  // namespace llvm
 
 #undef DEBUG_TYPE
-
-#endif

--- a/src/PointerAnalysis/Graph/ConstraintGraph/SCCIterator.h
+++ b/src/PointerAnalysis/Graph/ConstraintGraph/SCCIterator.h
@@ -12,8 +12,7 @@ limitations under the License.
 //
 // Created by peiming on 9/16/19.
 //
-#ifndef PTA_SCCITERATOR_H
-#define PTA_SCCITERATOR_H
+#pragma once
 
 #include <llvm/ADT/BitVector.h>
 
@@ -320,5 +319,3 @@ SCCIterator<ctx, cons, reverse> scc_end(const ConstraintGraph<ctx> &G, const llv
 }
 
 }  // namespace pta
-
-#endif

--- a/src/PointerAnalysis/Graph/GraphBase/GraphBase.h
+++ b/src/PointerAnalysis/Graph/GraphBase/GraphBase.h
@@ -12,8 +12,7 @@ limitations under the License.
 //
 // Created by peiming on 8/14/19.
 //
-#ifndef PTA_GRAPHBASE_H
-#define PTA_GRAPHBASE_H
+#pragma once
 
 #include <llvm/ADT/GraphTraits.h>
 
@@ -347,5 +346,3 @@ struct GraphTraits<Inverse<pta::GraphBase<NodeType, EdgeType>>> {
 };
 
 }  // namespace llvm
-
-#endif

--- a/src/PointerAnalysis/Models/LanguageModel/ConsGraphBuilder.h
+++ b/src/PointerAnalysis/Models/LanguageModel/ConsGraphBuilder.h
@@ -12,8 +12,7 @@ limitations under the License.
 //
 // Created by peiming on 10/22/19.
 //
-#ifndef PTA_CONSGRAPHBUILDER_H
-#define PTA_CONSGRAPHBUILDER_H
+#pragma once
 
 #include <llvm/ADT/SparseBitVector.h>
 #include <llvm/Demangle/Demangle.h>
@@ -681,5 +680,3 @@ struct hash<pair<T1 *, T2 *>> {
 
 #undef MODEL
 #undef ALLOCATE
-
-#endif

--- a/src/PointerAnalysis/Models/LanguageModel/DefaultLangModel/DefaultExtFunctions.h
+++ b/src/PointerAnalysis/Models/LanguageModel/DefaultLangModel/DefaultExtFunctions.h
@@ -12,8 +12,7 @@ limitations under the License.
 //
 // Created by peiming on 11/13/19.
 //
-#ifndef PTA_DEFAULTEXTFUNCTIONS_H
-#define PTA_DEFAULTEXTFUNCTIONS_H
+#pragma once
 
 #include <llvm/IR/Function.h>
 
@@ -34,5 +33,3 @@ class DefaultExtFunctions {
 };
 
 }  // namespace pta
-
-#endif

--- a/src/PointerAnalysis/Models/LanguageModel/DefaultLangModel/DefaultLangModel.h
+++ b/src/PointerAnalysis/Models/LanguageModel/DefaultLangModel/DefaultLangModel.h
@@ -12,8 +12,7 @@ limitations under the License.
 //
 // Created by peiming on 10/22/19.
 //
-#ifndef PTA_DEFAULTLANGMODEL_H
-#define PTA_DEFAULTLANGMODEL_H
+#pragma once
 
 #include "DefaultExtFunctions.h"
 #include "Logging/Log.h"
@@ -160,5 +159,3 @@ class LangModelTrait<DefaultLangModel<ctx, MemModel, PtsTy>>
     : public LangModelTrait<LangModelBase<ctx, MemModel, PtsTy, DefaultLangModel<ctx, MemModel, PtsTy>>> {};
 
 }  // namespace pta
-
-#endif

--- a/src/PointerAnalysis/Models/LanguageModel/InterceptResult.h
+++ b/src/PointerAnalysis/Models/LanguageModel/InterceptResult.h
@@ -13,8 +13,7 @@ limitations under the License.
 // Created by peiming on 7/21/20.
 //
 
-#ifndef PTA_INTERCEPTRESULT_H
-#define PTA_INTERCEPTRESULT_H
+#pragma once
 
 // forward declaration
 namespace llvm {
@@ -39,4 +38,3 @@ struct InterceptResult {
 };
 
 }  // namespace pta
-#endif

--- a/src/PointerAnalysis/Models/LanguageModel/LangModelBase.h
+++ b/src/PointerAnalysis/Models/LanguageModel/LangModelBase.h
@@ -13,8 +13,7 @@ limitations under the License.
 // Created by peiming on 1/16/20.
 //
 
-#ifndef PTA_LANGMODELBASE_H
-#define PTA_LANGMODELBASE_H
+#pragma once
 
 #include "ConsGraphBuilder.h"
 #include "PointerAnalysis/Util/Util.h"
@@ -271,4 +270,3 @@ struct LangModelTrait<LangModelBase<ctx, MemModel, PtsTy, SubClass>> {
 };
 
 }  // namespace pta
-#endif

--- a/src/PointerAnalysis/Models/LanguageModel/LangModelTrait.h
+++ b/src/PointerAnalysis/Models/LanguageModel/LangModelTrait.h
@@ -12,8 +12,7 @@ limitations under the License.
 //
 // Created by peiming on 10/19/19.
 //
-#ifndef PTA_LANGMODELTRAIT_H
-#define PTA_LANGMODELTRAIT_H
+#pragma once
 
 #include <llvm/IR/LegacyPassManager.h>
 
@@ -71,5 +70,3 @@ struct LangModelTrait {
 };
 
 }  // namespace pta
-
-#endif

--- a/src/PointerAnalysis/Models/LanguageModel/PtrNodeManager.h
+++ b/src/PointerAnalysis/Models/LanguageModel/PtrNodeManager.h
@@ -13,8 +13,7 @@ limitations under the License.
 // Created by peiming on 7/23/20.
 //
 
-#ifndef PTA_PTRNODEMANAGER_H
-#define PTA_PTRNODEMANAGER_H
+#pragma once
 #include <unordered_map>
 
 #include "PointerAnalysis/Program/CtxFunction.h"
@@ -182,4 +181,3 @@ class PtrNodeManager : public SingleInstanceOwner<Pointer<ctx>> {
 };
 
 }  // namespace pta
-#endif

--- a/src/PointerAnalysis/Models/MemoryModel/CppMemModel/CppMemModel.h
+++ b/src/PointerAnalysis/Models/MemoryModel/CppMemModel/CppMemModel.h
@@ -13,8 +13,7 @@ limitations under the License.
 // Created by peiming on 7/13/20.
 //
 
-#ifndef PTA_CPPMEMMODEL_H
-#define PTA_CPPMEMMODEL_H
+#pragma once
 
 // TODO: there are a lot of things to do to model C++'s memory model accurately
 // besides vtable e.g., runtime type information + class hirachy, so we put it
@@ -305,5 +304,3 @@ struct MemModelTrait<cpp::CppMemModel<ctx>> : MemModelHelper<cpp::CppMemModel<ct
 #undef super
 
 }  // namespace pta
-
-#endif

--- a/src/PointerAnalysis/Models/MemoryModel/CppMemModel/PreprocessingPasses/RewriteModeledAPIPass.h
+++ b/src/PointerAnalysis/Models/MemoryModel/CppMemModel/PreprocessingPasses/RewriteModeledAPIPass.h
@@ -13,8 +13,7 @@ limitations under the License.
 // Created by peiming on 7/23/20.
 //
 
-#ifndef PTA_REWRITEMODELEDAPIPASS_H
-#define PTA_REWRITEMODELEDAPIPASS_H
+#pragma once
 
 #include <llvm/Pass.h>
 namespace pta::cpp {
@@ -28,5 +27,3 @@ class RewriteModeledAPIPass : public llvm::FunctionPass {
 };
 
 }  // namespace pta::cpp
-
-#endif

--- a/src/PointerAnalysis/Models/MemoryModel/CppMemModel/SpecialObject/VTablePtr.h
+++ b/src/PointerAnalysis/Models/MemoryModel/CppMemModel/SpecialObject/VTablePtr.h
@@ -20,8 +20,7 @@ limitations under the License.
 #include "PointerAnalysis/Models/MemoryModel/FieldSensitive/MemBlock.h"
 #include "PointerAnalysis/Util/TypeMetaData.h"
 
-#ifndef PTA_VTABLEPTR_H
-#define PTA_VTABLEPTR_H
+#pragma once
 
 namespace pta {
 
@@ -138,4 +137,3 @@ class VTablePtr : public FSObject<ctx> {
 };
 
 }  // namespace pta
-#endif

--- a/src/PointerAnalysis/Models/MemoryModel/CppMemModel/SpecialObject/Vector.h
+++ b/src/PointerAnalysis/Models/MemoryModel/CppMemModel/SpecialObject/Vector.h
@@ -13,8 +13,7 @@ limitations under the License.
 // Created by peiming on 7/21/20.
 //
 
-#ifndef PTA_VECTOR_H
-#define PTA_VECTOR_H
+#pragma once
 
 #include <llvm/IR/Type.h>
 
@@ -193,5 +192,3 @@ class Vector : public FSObject<ctx> {
 };
 
 }  // namespace pta::cpp
-
-#endif

--- a/src/PointerAnalysis/Models/MemoryModel/DefaultHeapModel.h
+++ b/src/PointerAnalysis/Models/MemoryModel/DefaultHeapModel.h
@@ -13,8 +13,7 @@ limitations under the License.
 // Created by peiming on 1/16/20.
 //
 
-#ifndef PTA_DEFAULTHEAPMODEL_H
-#define PTA_DEFAULTHEAPMODEL_H
+#pragma once
 
 #include <llvm/IR/Function.h>
 #include <llvm/IR/Instructions.h>
@@ -71,5 +70,3 @@ class DefaultHeapModel {
 };
 
 }  // namespace pta
-
-#endif

--- a/src/PointerAnalysis/Models/MemoryModel/FieldInsensitive/FICanonicalizer.h
+++ b/src/PointerAnalysis/Models/MemoryModel/FieldInsensitive/FICanonicalizer.h
@@ -12,8 +12,7 @@ limitations under the License.
 //
 // Created by peiming on 11/3/19.
 //
-#ifndef PTA_FICANONICALIZER_H
-#define PTA_FICANONICALIZER_H
+#pragma once
 
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/Intrinsics.h>
@@ -30,5 +29,3 @@ class FICanonicalizer {
 };
 
 }  // namespace pta
-
-#endif

--- a/src/PointerAnalysis/Models/MemoryModel/FieldInsensitive/FIMemModel.h
+++ b/src/PointerAnalysis/Models/MemoryModel/FieldInsensitive/FIMemModel.h
@@ -22,8 +22,7 @@ limitations under the License.
 // for field-sensitive memory langModel
 // one memory block -> multiple static objects
 
-#ifndef PTA_FIMEMMODEL_H
-#define PTA_FIMEMMODEL_H
+#pragma once
 
 #include <llvm/IR/LegacyPassManager.h>
 
@@ -176,5 +175,3 @@ struct MemModelTrait<FIMemModel<ctx>> : public MemModelHelper<FIMemModel<ctx>> {
 };
 
 }  // namespace pta
-
-#endif

--- a/src/PointerAnalysis/Models/MemoryModel/FieldInsensitive/FIObject.h
+++ b/src/PointerAnalysis/Models/MemoryModel/FieldInsensitive/FIObject.h
@@ -12,8 +12,7 @@ limitations under the License.
 //
 // Created by peiming on 11/3/19.
 //
-#ifndef PTA_FIOBJECT_H
-#define PTA_FIOBJECT_H
+#pragma once
 
 #include "PointerAnalysis/Program/AllocSite.h"
 
@@ -106,5 +105,3 @@ struct hash<pta::FIObject<ctx>> {
 };
 
 }  // namespace std
-
-#endif

--- a/src/PointerAnalysis/Models/MemoryModel/FieldSensitive/FSCanonicalizer.h
+++ b/src/PointerAnalysis/Models/MemoryModel/FieldSensitive/FSCanonicalizer.h
@@ -13,8 +13,7 @@ limitations under the License.
 // Created by peiming on 1/2/20.
 //
 
-#ifndef PTA_FSCANONICALIZER_H
-#define PTA_FSCANONICALIZER_H
+#pragma once
 
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/Intrinsics.h>
@@ -29,5 +28,3 @@ class FSCanonicalizer {
 };
 
 }  // namespace pta
-
-#endif

--- a/src/PointerAnalysis/Models/MemoryModel/FieldSensitive/FSMemModel.h
+++ b/src/PointerAnalysis/Models/MemoryModel/FieldSensitive/FSMemModel.h
@@ -12,8 +12,7 @@ limitations under the License.
 //
 // Created by peiming on 12/18/19.
 //
-#ifndef PTA_FSMEMMODEL_H
-#define PTA_FSMEMMODEL_H
+#pragma once
 
 #include <llvm/Support/Allocator.h>
 
@@ -612,4 +611,3 @@ struct MemModelTrait<FSMemModel<ctx>> : MemModelHelper<FSMemModel<ctx>> {
 };
 
 }  // namespace pta
-#endif

--- a/src/PointerAnalysis/Models/MemoryModel/FieldSensitive/FSObject.h
+++ b/src/PointerAnalysis/Models/MemoryModel/FieldSensitive/FSObject.h
@@ -13,8 +13,7 @@ limitations under the License.
 // Created by peiming on 12/19/19.
 //
 
-#ifndef PTA_FSOBJECT_H
-#define PTA_FSOBJECT_H
+#pragma once
 
 #include <llvm/IR/GlobalValue.h>
 #include <llvm/Support/Casting.h>
@@ -167,5 +166,3 @@ class FSObject : public Object<ctx, FSObject<ctx>> {
 };
 
 }  // namespace pta
-
-#endif

--- a/src/PointerAnalysis/Models/MemoryModel/FieldSensitive/Layout/ArrayLayout.h
+++ b/src/PointerAnalysis/Models/MemoryModel/FieldSensitive/Layout/ArrayLayout.h
@@ -13,8 +13,7 @@ limitations under the License.
 // Created by peiming on 1/3/20.
 //
 
-#ifndef PTA_ARRAYLAYOUT_H
-#define PTA_ARRAYLAYOUT_H
+#pragma once
 
 #include <cassert>
 #include <limits>
@@ -75,5 +74,3 @@ class ArrayLayout {
 };
 
 }  // namespace pta
-
-#endif

--- a/src/PointerAnalysis/Models/MemoryModel/FieldSensitive/Layout/MemLayout.h
+++ b/src/PointerAnalysis/Models/MemoryModel/FieldSensitive/Layout/MemLayout.h
@@ -13,8 +13,7 @@ limitations under the License.
 // Created by peiming on 12/18/19.
 //
 
-#ifndef PTA_MEMLAYOUT_H
-#define PTA_MEMLAYOUT_H
+#pragma once
 
 #include <llvm/ADT/BitVector.h>
 #include <llvm/ADT/SparseBitVector.h>
@@ -173,5 +172,3 @@ class MemLayout {
 };
 
 }  // namespace pta
-
-#endif

--- a/src/PointerAnalysis/Models/MemoryModel/FieldSensitive/Layout/MemLayoutManager.h
+++ b/src/PointerAnalysis/Models/MemoryModel/FieldSensitive/Layout/MemLayoutManager.h
@@ -13,8 +13,7 @@ limitations under the License.
 // Created by peiming on 12/18/19.
 //
 
-#ifndef PTA_MEMLAYOUTMANAGER_H
-#define PTA_MEMLAYOUTMANAGER_H
+#pragma once
 
 #include <llvm/ADT/BitVector.h>
 #include <llvm/IR/Type.h>
@@ -260,5 +259,3 @@ class MemLayoutManager {
 };
 
 }  // namespace pta
-
-#endif

--- a/src/PointerAnalysis/Models/MemoryModel/FieldSensitive/Layout/Util.h
+++ b/src/PointerAnalysis/Models/MemoryModel/FieldSensitive/Layout/Util.h
@@ -13,8 +13,7 @@ limitations under the License.
 // Created by peiming on 5/19/21.
 //
 
-#ifndef OPENRACE_UTIL_H
-#define OPENRACE_UTIL_H
+#pragma once
 
 #include <stddef.h>
 
@@ -34,4 +33,3 @@ size_t getGEPStepSize(const llvm::GetElementPtrInst *GEP, const llvm::DataLayout
 bool isArrayExistAtOffset(const std::map<size_t, ArrayLayout *> &arrayMap, size_t pOffset, size_t elementSize);
 
 }  // namespace pta
-#endif  // OPENRACE_UTIL_H

--- a/src/PointerAnalysis/Models/MemoryModel/FieldSensitive/MemBlock.h
+++ b/src/PointerAnalysis/Models/MemoryModel/FieldSensitive/MemBlock.h
@@ -13,8 +13,7 @@ limitations under the License.
 // Created by peiming on 12/18/19.
 //
 
-#ifndef PTA_MEMBLOCK_H
-#define PTA_MEMBLOCK_H
+#pragma once
 
 #include <llvm/ADT/IndexedMap.h>
 #include <llvm/IR/DataLayout.h>
@@ -396,5 +395,3 @@ class AggregateMemBlock : public MemBlock<ctx> {
 };
 
 }  // namespace pta
-
-#endif

--- a/src/PointerAnalysis/Models/MemoryModel/MemModelTrait.h
+++ b/src/PointerAnalysis/Models/MemoryModel/MemModelTrait.h
@@ -12,8 +12,7 @@ limitations under the License.
 //
 // Created by peiming on 10/22/19.
 //
-#ifndef PTA_MEMMODELTRAIT_H
-#define PTA_MEMMODELTRAIT_H
+#pragma once
 
 #include <llvm/IR/IntrinsicInst.h>
 
@@ -201,5 +200,3 @@ struct MemModelHelper {
 };
 
 }  // namespace pta
-
-#endif

--- a/src/PointerAnalysis/PointerAnalysisPass.h
+++ b/src/PointerAnalysis/PointerAnalysisPass.h
@@ -13,8 +13,7 @@ limitations under the License.
 // Created by peiming on 3/24/20.
 //
 
-#ifndef PTA_POINTERANALYSISPASS_H
-#define PTA_POINTERANALYSISPASS_H
+#pragma once
 
 #include <bits/unique_ptr.h>
 #include <llvm/ADT/Hashing.h>
@@ -60,5 +59,3 @@ class PointerAnalysisPass : public llvm::ImmutablePass {
 
 template <typename Solver>
 char PointerAnalysisPass<Solver>::ID = 0;
-
-#endif

--- a/src/PointerAnalysis/Program/AllocSite.h
+++ b/src/PointerAnalysis/Program/AllocSite.h
@@ -12,8 +12,7 @@ limitations under the License.
 //
 // Created by peiming on 10/22/19.
 //
-#ifndef PTA_ALLOCSITE_H
-#define PTA_ALLOCSITE_H
+#pragma once
 
 #include <llvm/IR/GlobalValue.h>
 #include <llvm/IR/Operator.h>
@@ -88,5 +87,3 @@ class AllocSite {
 };
 
 }  // namespace pta
-
-#endif

--- a/src/PointerAnalysis/Program/CallSite.h
+++ b/src/PointerAnalysis/Program/CallSite.h
@@ -12,8 +12,7 @@ limitations under the License.
 //
 // Created by peiming on 11/5/19.
 //
-#ifndef PTA_CALLSITE_H
-#define PTA_CALLSITE_H
+#pragma once
 
 #include <llvm/IR/Instructions.h>
 
@@ -83,5 +82,3 @@ class CallSite {
 };
 
 }  // namespace pta
-
-#endif

--- a/src/PointerAnalysis/Program/CtxFunction.h
+++ b/src/PointerAnalysis/Program/CtxFunction.h
@@ -12,8 +12,7 @@ limitations under the License.
 //
 // Created by peiming on 10/30/19.
 //
-#ifndef PTA_CTXFUNCTION_H
-#define PTA_CTXFUNCTION_H
+#pragma once
 
 #include <llvm/Support/CommandLine.h>
 
@@ -146,5 +145,3 @@ class InDirectCallSite {
 };
 
 }  // namespace pta
-
-#endif

--- a/src/PointerAnalysis/Program/CtxModule.h
+++ b/src/PointerAnalysis/Program/CtxModule.h
@@ -12,8 +12,7 @@ limitations under the License.
 //
 // Created by peiming on 10/30/19.
 //
-#ifndef PTA_CTXMODULE_H
-#define PTA_CTXMODULE_H
+#pragma once
 
 #include <llvm/IR/Value.h>
 
@@ -366,5 +365,3 @@ class CtxModule {
 };
 
 }  // namespace pta
-
-#endif

--- a/src/PointerAnalysis/Program/Object.h
+++ b/src/PointerAnalysis/Program/Object.h
@@ -13,8 +13,7 @@ limitations under the License.
 // Created by peiming on 6/17/20.
 //
 
-#ifndef PTA_OBJECT_H
-#define PTA_OBJECT_H
+#pragma once
 
 #include "PointerAnalysis/Graph/NodeID.def"
 
@@ -75,4 +74,3 @@ template <typename ctx, typename SubClass>
 ObjID Object<ctx, SubClass>::CurID = 0;
 
 }  // namespace pta
-#endif

--- a/src/PointerAnalysis/Program/Pointer.h
+++ b/src/PointerAnalysis/Program/Pointer.h
@@ -12,8 +12,7 @@ limitations under the License.
 //
 // Created by peiming on 11/1/19.
 //
-#ifndef PTA_POINTER_H
-#define PTA_POINTER_H
+#pragma once
 
 #include "PointerAnalysis/Util/Util.h"
 
@@ -81,5 +80,3 @@ struct hash<pta::Pointer<ctx>> {
 };
 
 }  // namespace std
-
-#endif

--- a/src/PointerAnalysis/Solver/Andersen.h
+++ b/src/PointerAnalysis/Solver/Andersen.h
@@ -12,8 +12,7 @@ limitations under the License.
 //
 // Created by peiming on 9/17/19.
 //
-#ifndef PTA_ANDERSEN_H
-#define PTA_ANDERSEN_H
+#pragma once
 
 #include "SolverBase.h"
 
@@ -92,5 +91,3 @@ class Andersen : public SolverBase<LangModel, Andersen<LangModel>> {
 };
 
 }  // namespace pta
-
-#endif

--- a/src/PointerAnalysis/Solver/AndersenWave.h
+++ b/src/PointerAnalysis/Solver/AndersenWave.h
@@ -12,8 +12,7 @@ limitations under the License.
 //
 // Created by peiming on 9/16/19.
 //
-#ifndef PTA_ANDERSENWAVE_H
-#define PTA_ANDERSENWAVE_H
+#pragma once
 
 #include "PointerAnalysis/Graph/ConstraintGraph/SCCIterator.h"
 #include "SolverBase.h"
@@ -99,5 +98,3 @@ class AndersenWave : public SolverBase<LangModel, AndersenWave<LangModel>> {
 };
 
 }  // namespace pta
-
-#endif

--- a/src/PointerAnalysis/Solver/PartialUpdateSolver.h
+++ b/src/PointerAnalysis/Solver/PartialUpdateSolver.h
@@ -12,8 +12,7 @@ limitations under the License.
 //
 // Created by peiming on 2/25/20.
 //
-#ifndef PTA_PARTIALUPDATESOLVER_H
-#define PTA_PARTIALUPDATESOLVER_H
+#pragma once
 
 #include <stack>
 
@@ -371,5 +370,3 @@ class PartialUpdateSolver : public SolverBase<LangModel, PartialUpdateSolver<Lan
 //        true, true);
 
 }  // namespace pta
-
-#endif

--- a/src/PointerAnalysis/Solver/PointsTo/BitVectorPTS.h
+++ b/src/PointerAnalysis/Solver/PointsTo/BitVectorPTS.h
@@ -12,8 +12,7 @@ limitations under the License.
 //
 // Created by peiming on 9/9/19.
 //
-#ifndef PTA_BITVECTORPTS_H
-#define PTA_BITVECTORPTS_H
+#pragma once
 
 #include <llvm/ADT/SparseBitVector.h>
 
@@ -158,5 +157,3 @@ class BitVectorPTS {
 }  // namespace pta
 
 DEFINE_PTS_TRAIT(pta::BitVectorPTS)
-
-#endif

--- a/src/PointerAnalysis/Solver/PointsTo/PTSTrait.h
+++ b/src/PointerAnalysis/Solver/PointsTo/PTSTrait.h
@@ -12,8 +12,7 @@ limitations under the License.
 //
 // Created by peiming on 10/22/19.
 //
-#ifndef PTA_PTSTRAIT_H
-#define PTA_PTSTRAIT_H
+#pragma once
 
 #include "PointerAnalysis/Graph/NodeID.def"
 
@@ -114,5 +113,3 @@ struct PTSTrait {
             "instead ");                                                                               \
     }                                                                                                  \
   };
-
-#endif

--- a/src/PointerAnalysis/Solver/PointsTo/PointedByPts.h
+++ b/src/PointerAnalysis/Solver/PointsTo/PointedByPts.h
@@ -14,8 +14,7 @@ limitations under the License.
 //
 
 // the pts data structure that also stores pointed by information
-#ifndef PTA_POINTEDBYPTS_H
-#define PTA_POINTEDBYPTS_H
+#pragma once
 
 #include "PTSTrait.h"
 
@@ -151,5 +150,3 @@ class PointedByPts {
 }  // namespace pta
 
 DEFINE_PTS_TRAIT(pta::PointedByPts)
-
-#endif

--- a/src/PointerAnalysis/Solver/SolverBase.h
+++ b/src/PointerAnalysis/Solver/SolverBase.h
@@ -11,8 +11,7 @@ limitations under the License.
 
 // the basic framework for andersen-based algorithm, including common routines
 // override neccessary ones, and the call will be STATICALLY redirected to it
-#ifndef PTA_SOLVERBASE_H
-#define PTA_SOLVERBASE_H
+#pragma once
 
 #define DEBUG_TYPE "pta"
 
@@ -489,5 +488,3 @@ bool SolverBase<LangModel, SubClass>::processCopy(CGNodeTy *src, CGNodeTy *dst) 
 }  // namespace pta
 
 #undef DEBUG_TYPE
-
-#endif

--- a/src/PointerAnalysis/Util/CtxInstVisitor.h
+++ b/src/PointerAnalysis/Util/CtxInstVisitor.h
@@ -15,8 +15,7 @@ limitations under the License.
 // Modified from llvm::InstVisitor
 // instead of just visiting an instruction, it visit the instruction with
 // context
-#ifndef PTA_CTXINSTVISITOR_H
-#define PTA_CTXINSTVISITOR_H
+#pragma once
 
 #include "PointerAnalysis/Program/CtxFunction.h"
 //#include "llvm/IR/CallSite.h"
@@ -347,5 +346,3 @@ class CtxInstVisitor {
 #undef DELEGATE
 
 }  // namespace llvm
-
-#endif

--- a/src/PointerAnalysis/Util/GraphWriter.h
+++ b/src/PointerAnalysis/Util/GraphWriter.h
@@ -12,8 +12,7 @@ limitations under the License.
 //
 // Created by peiming on 9/3/19.
 //
-#ifndef PTA_GRAPHWRITER_H
-#define PTA_GRAPHWRITER_H
+#pragma once
 
 // a little modification on llvm build-in callgraph writer
 
@@ -269,5 +268,3 @@ void WriteGraphToFile(const std::string &graphName, const GraphType &graph, bool
 }
 
 }  // namespace pta
-
-#endif

--- a/src/PointerAnalysis/Util/Iterators.h
+++ b/src/PointerAnalysis/Util/Iterators.h
@@ -12,8 +12,7 @@ limitations under the License.
 //
 // Created by peiming on 11/8/19.
 //
-#ifndef PTA_ITERATORS_H
-#define PTA_ITERATORS_H
+#pragma once
 
 #include <llvm/ADT/iterator.h>
 
@@ -289,5 +288,3 @@ class NodeIDWrapperEdgeIterator
 };
 
 }  // namespace pta
-
-#endif

--- a/src/PointerAnalysis/Util/SingleInstanceOwner.h
+++ b/src/PointerAnalysis/Util/SingleInstanceOwner.h
@@ -12,8 +12,7 @@ limitations under the License.
 //
 // Created by peiming on 8/29/19.
 //
-#ifndef PTA_SINGLEINSTANCEOWNER_H
-#define PTA_SINGLEINSTANCEOWNER_H
+#pragma once
 
 #include <unordered_set>
 
@@ -85,5 +84,3 @@ class SingleInstanceOwner {
 };
 
 }  // namespace pta
-
-#endif

--- a/src/PointerAnalysis/Util/TypeMetaData.h
+++ b/src/PointerAnalysis/Util/TypeMetaData.h
@@ -13,8 +13,7 @@ limitations under the License.
 // Created by peiming on 8/26/20.
 //
 
-#ifndef PTA_TYPEMETADATA_H
-#define PTA_TYPEMETADATA_H
+#pragma once
 
 #include <llvm/ADT/SmallVector.h>
 
@@ -59,5 +58,3 @@ inline llvm::DIType *getBaseType(DebugInfoType *T) {
 
 std::size_t getDISize(llvm::DIDerivedType *T);
 }  // namespace pta
-
-#endif

--- a/src/PointerAnalysis/Util/Util.h
+++ b/src/PointerAnalysis/Util/Util.h
@@ -12,8 +12,7 @@ limitations under the License.
 //
 // Created by peiming on 8/14/19.
 //
-#ifndef PTA_UTIL_H
-#define PTA_UTIL_H
+#pragma once
 
 #include <llvm/ADT/iterator.h>
 //#include <llvm/IR/CallSite.h>
@@ -144,5 +143,3 @@ const llvm::Type *getTypeAtOffset(const llvm::Type *type, size_t offset, const l
 bool isZeroOffsetTypeInRootType(const llvm::Type *rootType, const llvm::Type *elemType, const llvm::DataLayout &);
 
 }  // namespace pta
-
-#endif

--- a/src/PreProcessing/Passes/CanonicalizeGEPPass.h
+++ b/src/PreProcessing/Passes/CanonicalizeGEPPass.h
@@ -13,8 +13,7 @@ limitations under the License.
 // Created by peiming on 1/6/20.
 //
 
-#ifndef PTA_CANONICALIZEGEPPASS_H
-#define PTA_CANONICALIZEGEPPASS_H
+#pragma once
 
 #include <llvm/IR/PassManager.h>
 
@@ -53,5 +52,3 @@ class LegacyCanonicalizeGEPPass : public llvm::FunctionPass {
 
   bool runOnFunction(llvm::Function &F) override;
 };
-
-#endif

--- a/src/PreProcessing/Passes/InsertGlobalCtorCallPass.h
+++ b/src/PreProcessing/Passes/InsertGlobalCtorCallPass.h
@@ -13,8 +13,7 @@ limitations under the License.
 // Created by peiming on 3/14/20.
 //
 
-#ifndef PTA_INSERTGLOBALCTORCALLPASS_H
-#define PTA_INSERTGLOBALCTORCALLPASS_H
+#pragma once
 
 #include <llvm/Pass.h>
 
@@ -25,5 +24,3 @@ class InsertGlobalCtorCallPass : public llvm::ModulePass {
 
   bool runOnModule(llvm::Module &M) override;
 };
-
-#endif

--- a/src/PreProcessing/Passes/LoweringMemCpyPass.h
+++ b/src/PreProcessing/Passes/LoweringMemCpyPass.h
@@ -13,8 +13,7 @@ limitations under the License.
 // Created by peiming on 1/22/20.
 //
 
-#ifndef PTA_LOWERINGMEMCPYPASS_H
-#define PTA_LOWERINGMEMCPYPASS_H
+#pragma once
 
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/Pass.h>
@@ -39,5 +38,3 @@ class LoweringMemCpyPass : public llvm::ModulePass {
 
   bool runOnModule(llvm::Module &) override;
 };
-
-#endif

--- a/src/PreProcessing/Passes/OMPConstantPropPass.h
+++ b/src/PreProcessing/Passes/OMPConstantPropPass.h
@@ -12,8 +12,7 @@ limitations under the License.
 // Created by peiming on 5/11/21.
 //
 
-#ifndef OPENRACE_OMPCONSTANTPROPPASS_H
-#define OPENRACE_OMPCONSTANTPROPPASS_H
+#pragma once
 
 #include <llvm/Analysis/TargetLibraryInfo.h>
 #include <llvm/IR/Dominators.h>
@@ -24,5 +23,3 @@ class OMPConstantPropPass : public llvm::PassInfoMixin<OMPConstantPropPass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &AM);
   static bool isRequired() { return true; }
 };
-
-#endif  // OPENRACE_OMPCONSTANTPROPPASS_H

--- a/src/PreProcessing/Passes/RemoveExceptionHandlerPass.h
+++ b/src/PreProcessing/Passes/RemoveExceptionHandlerPass.h
@@ -13,8 +13,7 @@ limitations under the License.
 // Created by peiming on 1/10/20.
 //
 
-#ifndef PTA_REMOVEEXCEPTIONHANDLERPASS_H
-#define PTA_REMOVEEXCEPTIONHANDLERPASS_H
+#pragma once
 
 #include <llvm/Pass.h>
 
@@ -26,5 +25,3 @@ class RemoveExceptionHandlerPass : public llvm::FunctionPass {
   bool runOnFunction(llvm::Function &F) override;
   bool doInitialization(llvm::Module &M) override;
 };
-
-#endif

--- a/tests/data/integration/dataracebench/polybench/3mm.h
+++ b/tests/data/integration/dataracebench/polybench/3mm.h
@@ -6,8 +6,7 @@
  * Web address: http://polybench.sourceforge.net
  * License: /LICENSE.OSU.txt
  */
-#ifndef _3MM_H
-# define _3MM_H
+#pragma once
 
 /* Default to STANDARD_DATASET. */
 # if !defined(TINY_DATASET) && !defined(MINI_DATASET) && !defined(SMALL_DATASET) && !defined(LARGE_DATASET) && !defined(EXTRALARGE_DATASET)
@@ -76,6 +75,3 @@
 #  define DATA_TYPE double
 #  define DATA_PRINTF_MODIFIER "%0.2lf "
 # endif
-
-
-#endif /* !_3MM */

--- a/tests/data/integration/dataracebench/polybench/adi.h
+++ b/tests/data/integration/dataracebench/polybench/adi.h
@@ -6,8 +6,7 @@
  * Web address: http://polybench.sourceforge.net
  * License: /LICENSE.OSU.txt
  */
-#ifndef ADI_H
-# define ADI_H
+#pragma once
 
 /* Default to STANDARD_DATASET. */
 # if !defined(TINY_DATASET) && !defined(MINI_DATASET) && !defined(SMALL_DATASET) && !defined(LARGE_DATASET) && !defined(EXTRALARGE_DATASET)
@@ -55,6 +54,3 @@
 #  define DATA_TYPE double
 #  define DATA_PRINTF_MODIFIER "%0.2lf "
 # endif
-
-
-#endif /* !ADI */

--- a/tests/data/integration/dataracebench/polybench/jacobi-2d-imper.h
+++ b/tests/data/integration/dataracebench/polybench/jacobi-2d-imper.h
@@ -6,8 +6,7 @@
  * Web address: http://polybench.sourceforge.net
  * License: /LICENSE.OSU.txt
  */
-#ifndef JACOBI_2D_IMPER_H
-# define JACOBI_2D_IMPER_H
+#pragma once
 
 /* Default to STANDARD_DATASET. */
 # if !defined(TINY_DATASET) && !defined(MINI_DATASET) && !defined(SMALL_DATASET) && !defined(LARGE_DATASET) && !defined(EXTRALARGE_DATASET)
@@ -55,6 +54,3 @@
 #  define DATA_TYPE double
 #  define DATA_PRINTF_MODIFIER "%0.2lf "
 # endif
-
-
-#endif /* !JACOBI_2D_IMPER */

--- a/tests/data/integration/dataracebench/polybench/polybench.h
+++ b/tests/data/integration/dataracebench/polybench/polybench.h
@@ -21,8 +21,7 @@
  * See README or utilities/polybench.c for additional options.
  *
  */
-#ifndef POLYBENCH_H
-# define POLYBENCH_H
+#pragma once
 
 # include <stdlib.h>
 
@@ -198,6 +197,3 @@ extern void polybench_papi_print();
 
 /* Function prototypes. */
 extern void* polybench_alloc_data(unsigned long long int n, int elt_size);
-
-
-#endif /* !POLYBENCH_H */


### PR DESCRIPTION
Closes #140

Replaces all instances of `#ifndef` header guards with `#pragma once`.
