### PR TITLE
Turn off warnings `-Wshadow` and `-Wuseless-cast`

### DIFF
--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -32,7 +32,7 @@ function(enable_warnings target_name)
     set(CLANG_WARNINGS
         -Wall
         -Wextra # reasonable and standard
-        -Wshadow # warn the user if a variable declaration shadows one from a parent context
+        # -Wshadow # warn the user if a variable declaration shadows one from a parent context
         -Wnon-virtual-dtor # warn the user if a class with virtual functions has a non-virtual destructor.
         -Wold-style-cast # warn for c-style casts
         -Wcast-align # warn for potential performance problem casts
@@ -52,7 +52,7 @@ function(enable_warnings target_name)
         -Wduplicated-cond # warn if if / else chain has duplicated conditions
         -Wduplicated-branches # warn if if / else branches have duplicated code
         -Wlogical-op # warn about logical operations being used where bitwise were probably wanted
-        -Wuseless-cast # warn if you perform a cast to the same type
+        # -Wuseless-cast # warn if you perform a cast to the same type
     )
 
     if(MSVC)

--- a/src/PointerAnalysis/Util/Iterators.h
+++ b/src/PointerAnalysis/Util/Iterators.h
@@ -105,7 +105,7 @@ struct ConcatIterator : public ConcatIterator<Wrapped, N - 1, ValueT> {
   inline bool operator!=(const self &rhs) const { return !this->operator==(rhs); }
 
   inline bool operator==(const self &rhs) const {
-    return cur == rhs.cur && ((const super *)this)->operator==((const super &)rhs);
+    return cur == rhs.cur && (static_cast<const super *>(this))->operator==(static_cast<const super &>(rhs));
   }
 
   //    auto operator-> () -> decltype(cur.operator->()) {
@@ -192,7 +192,7 @@ struct ConcatIteratorWithTag : public ConcatIteratorWithTag<Wrapped, N - 1, E, V
   inline bool operator!=(const self &rhs) const { return !this->operator==(rhs); }
 
   inline bool operator==(const self &rhs) const {
-    return cur == rhs.cur && static_cast<const super *>(this)->operator==((const super &)rhs);
+    return cur == rhs.cur && (static_cast<const super *>(this))->operator==(static_cast<const super &>(rhs));
   }
 };
 


### PR DESCRIPTION
`-Wshadow`:
Changing the shadowed parameters will introduce weird compile errors, cannot solve those errors.

`-Wuseless-cast`:
These warnings comes from (and similar usage of `I`):
```c
../src/PointerAnalysis/Util/CtxInstVisitor.h:121:85: warning: useless cast to type ‘class llvm::Instruction&’ [-Wuseless-cast]
  121 |     return static_cast<SubClass *>(this)->visit##OPCODE(static_cast<llvm::CLASS &>(I), context);
```
However, remove the cast will introduce error: 
```c
../src/PointerAnalysis/Util/CtxInstVisitor.h:121:67: error: cannot convert ‘llvm::Instruction’ to ‘llvm::ReturnInst&’
  121 |     return static_cast<SubClass *>(this)->visit##OPCODE(I, context);
```
