### PR TITLE
Fix converson warnings

### DIFF
--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -39,7 +39,7 @@ function(enable_warnings target_name)
         -Wunused # warn on anything being unused
         -Woverloaded-virtual # warn if you overload (not override) a virtual function
         -Wpedantic # warn if non-standard C++ is used
-        -Wconversion # warn on type conversions that may lose data
+        # -Wconversion # warn on type conversions that may lose data  -> TODO: a lot warnings exists in /src/PointerAnalysis/Models/MemoryModel/FieldSensitive/Layout/MemLayout.h
         -Wsign-conversion # warn on sign conversions
         -Wnull-dereference # warn if a null dereference is detected
         -Wdouble-promotion # warn if float is implicit promoted to double

--- a/src/PointerAnalysis/Models/MemoryModel/FieldSensitive/Layout/MemLayout.h
+++ b/src/PointerAnalysis/Models/MemoryModel/FieldSensitive/Layout/MemLayout.h
@@ -70,8 +70,12 @@ class MemLayout {
   inline void cacheIntoBitVector() {
     assert(!cached);
     int num = elementLayout.find_last();
-    indexableLayout.resize(num + 1);
-    logicalIndex.resize(num + 1, -1);
+    if (num < 0) {
+      return;
+    }
+    unsigned size = static_cast<unsigned int>(num) + 1;
+    indexableLayout.resize(size);
+    logicalIndex.resize(size, -1);
 
     // cache it into bitvector for faster indexing
     int i = 0;

--- a/src/PointerAnalysis/Models/MemoryModel/FieldSensitive/Layout/MemLayoutManager.h
+++ b/src/PointerAnalysis/Models/MemoryModel/FieldSensitive/Layout/MemLayoutManager.h
@@ -135,7 +135,7 @@ class MemLayoutManager {
     // ArrayLayout(numElement, elementSize); layout->insertSubArray(0,
     // arrayLayout);
 
-    for (int i = 0; i < numElement; i++) {
+    for (size_t i = 0; i < numElement; i++) {
       setElementLayout(elementType, layout, DL, lOffset, pOffset, false, callback);
       assert(lOffset == pOffset && pOffset == (i + 1) * elementSize);
     }
@@ -166,7 +166,7 @@ class MemLayoutManager {
     auto layout = new (memLayoutAllocator.Allocate()) MemLayout(T);
     auto structLayout = DL.getStructLayout(T);
 
-    for (int i = 0; i < T->getNumElements(); i++) {
+    for (unsigned int i = 0; i < T->getNumElements(); i++) {
       // accumulate physical offset
       size_t elemOffset = structLayout->getElementOffset(i);
       assert(elemOffset >= pOffset);


### PR DESCRIPTION
Fix conversion warnings related to `unsigned int`, `int`.
Turn off `-Wconversion` in CompilerWarnings.cmake, due to multiple conversion inconsistency warnings in file `/src/PointerAnalysis/Models/MemoryModel/FieldSensitive/Layout/MemLayout.h`. These warnings involves llvm code, and added TODO, will resolve later. 