### PR TITLE
Fix unused-variable and minor warnings

### DIFF
--- a/src/Analysis/LockSet.cpp
+++ b/src/Analysis/LockSet.cpp
@@ -43,7 +43,7 @@ std::set<const llvm::Value *> heldLocks(const Event *targetEvent) {
 }
 }  // namespace
 
-LockSet::LockSet(const ProgramTrace &program) {}
+LockSet::LockSet(const ProgramTrace & /* program */) {}
 
 // TODO: real implementation later
 bool LockSet::sharesLock(const MemAccessEvent *lhs, const MemAccessEvent *rhs) const {

--- a/src/LanguageModel/RaceModel.cpp
+++ b/src/LanguageModel/RaceModel.cpp
@@ -22,8 +22,8 @@ RaceModel::RaceModel(llvm::Module *M, llvm::StringRef entry) : Super(M, entry) {
       [&](const ctx *context, const llvm::Instruction *I) -> bool { return this->isInvokingAnOrigin(context, I); });
 }
 
-InterceptResult RaceModel::interceptFunction(const ctx *callerCtx, const ctx *calleeCtx, const llvm::Function *F,
-                                             const llvm::Instruction *callsite) {
+InterceptResult RaceModel::interceptFunction(const ctx * /* callerCtx */, const ctx * /* calleeCtx */,
+                                             const llvm::Function *F, const llvm::Instruction *callsite) {
   auto funcName = F->getName();
 
   // Skip intrinsic in PTA
@@ -97,14 +97,14 @@ bool RaceModel::interceptCallSite(const CtxFunction<ctx> *caller, const CtxFunct
   return false;
 }
 
-bool RaceModel::isCompatible(const llvm::Instruction *callsite, const llvm::Function *target) {
+bool RaceModel::isCompatible(const llvm::Instruction * /* callsite */, const llvm::Function * /* target */) {
   llvm_unreachable("unrecognizable function");
 }
 
-void RaceModel::interceptHeapAllocSite(const CtxFunction<ctx> *caller, const CtxFunction<ctx> *callee,
-                                       const llvm::Instruction *callsite) {}
+void RaceModel::interceptHeapAllocSite(const CtxFunction<ctx> * /* caller */, const CtxFunction<ctx> * /* callee */,
+                                       const llvm::Instruction * /* callsite */) {}
 
-bool RaceModel::isHeapAllocAPI(const llvm::Function *F, const llvm::Instruction *callsite) {
+bool RaceModel::isHeapAllocAPI(const llvm::Function *F, const llvm::Instruction * /* callsite */) {
   if (!F->hasName()) return false;
   auto const name = F->getName();
   return name.equals("malloc") || name.equals("calloc") || name.equals("_Zname") || name.equals("_Znwm");
@@ -115,7 +115,7 @@ namespace {
 const std::set<llvm::StringRef> origins{"pthread_create", "__kmpc_fork_call"};
 }  // namespace
 
-bool RaceModel::isInvokingAnOrigin(const ctx *prevCtx, const llvm::Instruction *I) {
+bool RaceModel::isInvokingAnOrigin(const ctx * /* prevCtx */, const llvm::Instruction *I) {
   auto call = llvm::dyn_cast<CallBase>(I);
   if (!call || !call->getCalledFunction() || !call->getCalledFunction()->hasName()) return false;
 

--- a/src/PointerAnalysis/Context/KCallSite.h
+++ b/src/PointerAnalysis/Context/KCallSite.h
@@ -79,11 +79,12 @@ class KCallSite {
   bool empty() const { return getLast() == nullptr; };
 
   bool operator==(const self &rhs) const {
+    // bz: seems like it is comparing this and rhs, but where is the use of rhs?? fix this by assigning xx2 to rhs's
     auto it1 = this->begin();
-    auto it2 = this->begin();
+    auto it2 = rhs.begin();
 
     auto ie1 = this->end();
-    auto ie2 = this->end();
+    auto ie2 = rhs.end();
 
     for (; it1 != ie1; it1++, it2++) {
       if (*it1 != *it2) {

--- a/src/PointerAnalysis/Context/NoCtx.h
+++ b/src/PointerAnalysis/Context/NoCtx.h
@@ -32,7 +32,7 @@ struct CtxTrait<NoCtx> {
   constexpr static const NoCtx* getInitialCtx() { return nullptr; }
   constexpr static const NoCtx* getGlobalCtx() { return nullptr; }
 
-  inline static std::string toString(const NoCtx*, bool detailed = false) { return "<Empty>"; }
+  inline static std::string toString(const NoCtx*, bool /* detailed */ = false) { return "<Empty>"; }
   inline static void release(){};
 };
 

--- a/src/PointerAnalysis/Graph/CallGraph.h
+++ b/src/PointerAnalysis/Graph/CallGraph.h
@@ -156,7 +156,7 @@ struct DOTGraphTraits<const pta::CallGraph<ctx>> : public DefaultDOTGraphTraits 
   static std::string getGraphName(const pta::CallGraph<ctx> &) { return "CallGraph"; }
 
   /// Return function name;
-  static std::string getNodeLabel(const pta::CallGraphNode<ctx> *node, const pta::CallGraph<ctx> &graph) {
+  static std::string getNodeLabel(const pta::CallGraphNode<ctx> *node, const pta::CallGraph<ctx> & /* graph */) {
     std::string str;
     raw_string_ostream os(str);
     os << pta::CtxTrait<ctx>::toString(node->getContext()) << "\n";

--- a/src/PointerAnalysis/Graph/ConstraintGraph/CGPtrNode.h
+++ b/src/PointerAnalysis/Graph/ConstraintGraph/CGPtrNode.h
@@ -27,6 +27,7 @@ class ConstraintGraph;
 
 struct PtrNodeTag {
   virtual std::string toString() = 0;
+  virtual ~PtrNodeTag(){};
 };
 
 // nodes represent pointers

--- a/src/PointerAnalysis/Graph/ConstraintGraph/ConstraintGraph.h
+++ b/src/PointerAnalysis/Graph/ConstraintGraph/ConstraintGraph.h
@@ -32,6 +32,7 @@ class ConstraintGraph : public GraphBase<CGNodeBase<ctx>, Constraints> {
  public:
   using CGNodeTy = CGNodeBase<ctx>;
   struct OnNewConstraintCallBack {
+    virtual ~OnNewConstraintCallBack() {}
     virtual void onNewConstraint(CGNodeTy *src, CGNodeTy *dst, Constraints constraint) = 0;
   };
 
@@ -194,7 +195,7 @@ struct DOTGraphTraits<const pta::ConstraintGraph<ctx>> : public DefaultDOTGraphT
   static std::string getGraphName(const GraphTy &) { return "constraint_graph"; }
 
   /// Return function name;
-  static std::string getNodeLabel(const NodeTy *node, const GraphTy &graph) {
+  static std::string getNodeLabel(const NodeTy *node, const GraphTy & /* graph */) {
     std::string str;
     raw_string_ostream os(str);
 
@@ -202,7 +203,7 @@ struct DOTGraphTraits<const pta::ConstraintGraph<ctx>> : public DefaultDOTGraphT
     return os.str();
   }
 
-  static std::string getNodeAttributes(const NodeTy *node, const GraphTy &graph) {
+  static std::string getNodeAttributes(const NodeTy * /* node */, const GraphTy & /* graph */) {
     //        if (isa<CGPtrNode<ctx>>(node)) {
     //            return "";
     //        } else if (isa<CGSuperNode<ctx, PtsTy>>(node)) {
@@ -214,7 +215,7 @@ struct DOTGraphTraits<const pta::ConstraintGraph<ctx>> : public DefaultDOTGraphT
   }
 
   template <typename EdgeIter>
-  static std::string getEdgeAttributes(const NodeTy *node, EdgeIter EI, const GraphTy &graph) {
+  static std::string getEdgeAttributes(const NodeTy * /* node */, EdgeIter EI, const GraphTy & /* graph */) {
     pta::Constraints edgeTy = (*EI).first;
     switch (edgeTy) {
       case pta::Constraints::load:

--- a/src/PointerAnalysis/Models/LanguageModel/ConsGraphBuilder.h
+++ b/src/PointerAnalysis/Models/LanguageModel/ConsGraphBuilder.h
@@ -184,7 +184,7 @@ class ConsGraphBuilder : public llvm::CtxInstVisitor<ctx, SubClass>, public PtrN
 
       // TODO: track if the points-to of a funcPtr has changed?
       // TODO: maintain a map from funcPtr to its newly added function object?
-      uint8_t count = 0;
+      // uint8_t count = 0;
 
       for (auto it = pointsTo.begin(), eit = pointsTo.end(); it != eit; it++) {
         // count++;
@@ -406,12 +406,13 @@ class ConsGraphBuilder : public llvm::CtxInstVisitor<ctx, SubClass>, public PtrN
     PtrNodeManager<ctx>::template init<PT>(consGraph.get(), M->getContext());
 
     Object<ctx, ObjT>::resetObjectID();
+
+    // enable this if you want the special nodes to appear in the points to set
+#ifdef SPECIAL_NODE_IN_PTS
     // null and universal object nodes;
     CGNodeBase<ctx> *nullObj = ALLOCATE(NullObj, module->getLLVMModule());
     CGNodeBase<ctx> *uniObj = ALLOCATE(UniObj, module->getLLVMModule());
 
-    // enable this if you want the special nodes to appear in the points to set
-#ifdef SPECIAL_NODE_IN_PTS
     consGraph->addConstraints(nullObj, nullPtrNode, Constraints::addr_of);
     PT::insert(nullPtrNode->getNodeID(), nullObj->getNodeID());
 
@@ -516,7 +517,7 @@ class ConsGraphBuilder : public llvm::CtxInstVisitor<ctx, SubClass>, public PtrN
       // store a pointer into memory
       // store *src into **dst
 #ifndef NDEBUG
-      const llvm::Value *src = Canonicalizer::canonicalize(I.getValueOperand());
+      // const llvm::Value *src = Canonicalizer::canonicalize(I.getValueOperand());
       const llvm::Value *dst = Canonicalizer::canonicalize(I.getPointerOperand());
 
       if (dst == this->getUniPtr()->getPointer()->getValue() || dst == this->getNullPtr()->getPointer()->getValue()) {
@@ -597,32 +598,35 @@ class ConsGraphBuilder : public llvm::CtxInstVisitor<ctx, SubClass>, public PtrN
   inline void visitExtractValueInst(llvm::ExtractValueInst &I, const ctx *context) {
     if (I.getType()->isPointerTy()) {
       LOG_TRACE("Extract a pointer is not handled! inst={}", I);
-      auto dst = this->getOrCreatePtrNode(context, &I);
+      // auto dst = this->getOrCreatePtrNode(context, &I); // bz: comment off to avoid -Wunused-variable on dst, this
+      // needs to be kept for future use
     }
   }
 
-  inline void visitInsertValueInst(llvm::InsertValueInst &I, const ctx *context) {}
+  // bz: the following functions are not implemented/finished, comment off to avoid warnings; add back if requiring
+  // changes inline void visitInsertValueInst(llvm::InsertValueInst &I, const ctx *context) {}
 
-  // corner cases
-  inline void visitAtomicCmpXchgInst(llvm::AtomicCmpXchgInst &I, const ctx *context) {}
-  inline void visitAtomicRMWInst(llvm::AtomicRMWInst &I, const ctx *context) {}
-  inline void visitVAArgInst(llvm::VAArgInst &I, const ctx *context) {}
+  // // corner cases
+  // inline void visitAtomicCmpXchgInst(llvm::AtomicCmpXchgInst &I, const ctx *context) {}
+  // inline void visitAtomicRMWInst(llvm::AtomicRMWInst &I, const ctx *context) {}
+  // inline void visitVAArgInst(llvm::VAArgInst &I, const ctx *context) {}
 
-  // vector operations
-  inline void visitExtractElementInst(llvm::ExtractElementInst &I, const ctx *context) {}
-  inline void visitInsertElementInst(llvm::InsertElementInst &I, const ctx *context) {}
-  inline void visitShuffleVectorInst(llvm::ShuffleVectorInst &I, const ctx *context) {}
+  // // vector operations
+  // inline void visitExtractElementInst(llvm::ExtractElementInst &I, const ctx *context) {}
+  // inline void visitInsertElementInst(llvm::InsertElementInst &I, const ctx *context) {}
+  // inline void visitShuffleVectorInst(llvm::ShuffleVectorInst &I, const ctx *context) {}
 
-  // instrinsic instruction classes.
-  inline void visitMemSetInst(llvm::MemSetInst &I, const ctx *context) {}
-  inline void visitMemMoveInst(llvm::MemMoveInst &I, const ctx *context) {}
+  // // instrinsic instruction classes.
+  // inline void visitMemSetInst(llvm::MemSetInst &I, const ctx *context) {}
+  // inline void visitMemMoveInst(llvm::MemMoveInst &I, const ctx *context) {}
 
-  // need to be handled? but no one use it.
-  inline void visitVAStartInst(llvm::VAStartInst &I, const ctx *context) {}
-  inline void visitVAEndInst(llvm::VAEndInst &I, const ctx *context) {}
-  inline void visitVACopyInst(llvm::VACopyInst &I, const ctx *context) {}
+  // // need to be handled? but no one use it.
+  // inline void visitVAStartInst(llvm::VAStartInst &I, const ctx *context) {}
+  // inline void visitVAEndInst(llvm::VAEndInst &I, const ctx *context) {}
+  // inline void visitVACopyInst(llvm::VACopyInst &I, const ctx *context) {}
 
   inline void visitFreezeInst(llvm::FreezeInst &I, const ctx *context) {}
+
   // getters
   inline MemModel &getMemModel() { return memModel; }
 

--- a/src/PointerAnalysis/Models/LanguageModel/ConsGraphBuilder.h
+++ b/src/PointerAnalysis/Models/LanguageModel/ConsGraphBuilder.h
@@ -407,12 +407,12 @@ class ConsGraphBuilder : public llvm::CtxInstVisitor<ctx, SubClass>, public PtrN
 
     Object<ctx, ObjT>::resetObjectID();
 
-    // enable this if you want the special nodes to appear in the points to set
-#ifdef SPECIAL_NODE_IN_PTS
     // null and universal object nodes;
     CGNodeBase<ctx> *nullObj = ALLOCATE(NullObj, module->getLLVMModule());
     CGNodeBase<ctx> *uniObj = ALLOCATE(UniObj, module->getLLVMModule());
 
+    // enable this if you want the special nodes to appear in the points to set
+#ifdef SPECIAL_NODE_IN_PTS
     consGraph->addConstraints(nullObj, nullPtrNode, Constraints::addr_of);
     PT::insert(nullPtrNode->getNodeID(), nullObj->getNodeID());
 

--- a/src/PointerAnalysis/Models/LanguageModel/DefaultLangModel/DefaultLangModel.h
+++ b/src/PointerAnalysis/Models/LanguageModel/DefaultLangModel/DefaultLangModel.h
@@ -49,7 +49,7 @@ class DefaultLangModel : public LangModelBase<ctx, MemModel, PtsTy, DefaultLangM
     return heapModel.isHeapAllocFun(F);
   }
 
-  bool isHeapAllocAPI(const llvm::Function *F, const llvm::Instruction *callSite = nullptr) {
+  bool isHeapAllocAPI(const llvm::Function *F, const llvm::Instruction * /* callSite = nullptr */) {
     return heapModel.isHeapAllocFun(F);
   }
 
@@ -89,8 +89,8 @@ class DefaultLangModel : public LangModelBase<ctx, MemModel, PtsTy, DefaultLangM
   }
 
   // determine whether the function need to be modelled
-  inline InterceptResult interceptFunction(const ctx *callerCtx, const ctx *calleeCtx, const llvm::Function *F,
-                                           const llvm::Instruction *callsite) {
+  inline InterceptResult interceptFunction(const ctx * /* callerCtx */, const ctx * /* calleeCtx */,
+                                           const llvm::Function *F, const llvm::Instruction *callsite) {
     const llvm::Function *fun = F;
     if (F->isIntrinsic()) {
       return {nullptr, InterceptResult::Option::IGNORE_FUN};
@@ -117,7 +117,7 @@ class DefaultLangModel : public LangModelBase<ctx, MemModel, PtsTy, DefaultLangM
 
   // modelling a callsite
   inline bool interceptCallSite(const CtxFunction<ctx> *caller, const CtxFunction<ctx> *callee,
-                                const llvm::Function *originalTarget, const llvm::Instruction *callsite) {
+                                const llvm::Function * /* originalTarget */, const llvm::Instruction *callsite) {
     // the rule of context evolution should be obeyed.
     pta::CallSite CS(callsite);
     assert(CS.isCallOrInvoke());

--- a/src/PointerAnalysis/Models/LanguageModel/LangModelBase.h
+++ b/src/PointerAnalysis/Models/LanguageModel/LangModelBase.h
@@ -74,8 +74,8 @@ class LangModelBase : public ConsGraphBuilder<ctx, MemModel, PtsTy, SubClass> {
     }
   }
 
-  inline IndirectResolveOption onNewIndirectTargetResolvation(const llvm::Function *F,
-                                                              const llvm::Instruction *callsite) {
+  inline IndirectResolveOption onNewIndirectTargetResolvation(const llvm::Function * /* F */,
+                                                              const llvm::Instruction * /* callsite */) {
     // by default
     return IndirectResolveOption::WITH_LIMIT;
   }

--- a/src/PointerAnalysis/Models/MemoryModel/CppMemModel/CppMemModel.h
+++ b/src/PointerAnalysis/Models/MemoryModel/CppMemModel/CppMemModel.h
@@ -189,7 +189,7 @@ class CppMemModel : public FSMemModel<ctx> {
         elem = AT->getArrayElementType();  // strip array
       }
 
-      llvm::Type *vecElemType = nullptr;
+      // llvm::Type *vecElemType = nullptr;
       while (auto ST = llvm::dyn_cast<llvm::StructType>(elem)) {
         auto result = VectorAPI::resolveVecElemType(ST);
         if (result != nullptr) {
@@ -240,7 +240,7 @@ class CppMemModel : public FSMemModel<ctx> {
     super initializeGlobal<PT>(gVar, DL);
   }
 
-  inline InterceptResult interceptFunction(const llvm::Function *F, const llvm::Instruction *callSite) {
+  inline InterceptResult interceptFunction(const llvm::Function *F, const llvm::Instruction * /* callSite */) {
     // does not matter as they function body should be deleted by
     // RewriteModeledAPIPass
     return {F, InterceptResult::Option::EXPAND_BODY};

--- a/src/PointerAnalysis/Models/MemoryModel/CppMemModel/SpecialObject/Vector.h
+++ b/src/PointerAnalysis/Models/MemoryModel/CppMemModel/SpecialObject/Vector.h
@@ -59,13 +59,13 @@ class VectorAPI {
 
  public:
   explicit VectorAPI(const llvm::Instruction *call)
-      : APICall(llvm::dyn_cast_or_null<llvm::CallBase>(call)), vecElemType(nullptr), kind(APIKind::UNKNOWN) {
+      : kind(APIKind::UNKNOWN), APICall(llvm::dyn_cast_or_null<llvm::CallBase>(call)), vecElemType(nullptr) {
     if (APICall != nullptr) {
       init(APICall->getCalledFunction());
     }
   }
 
-  explicit VectorAPI(const llvm::Function *F) : APICall(nullptr), vecElemType(nullptr), kind(APIKind::UNKNOWN) {
+  explicit VectorAPI(const llvm::Function *F) : kind(APIKind::UNKNOWN), APICall(nullptr), vecElemType(nullptr) {
     init(F);
   }
 
@@ -140,7 +140,7 @@ class Vector : public FSObject<ctx> {
 
  public:
   // *src* can points to theVec
-  bool processSpecial(CGNodeBase<ctx> *src, CGNodeBase<ctx> *dst) const override {
+  bool processSpecial(CGNodeBase<ctx> * /* src */, CGNodeBase<ctx> *dst) const override {
     bool changed = false;
 
     auto consGraph = static_cast<ConsGraph *>(dst->getGraph());

--- a/src/PointerAnalysis/Models/MemoryModel/FieldSensitive/FSMemModel.h
+++ b/src/PointerAnalysis/Models/MemoryModel/FieldSensitive/FSMemModel.h
@@ -577,14 +577,15 @@ class FSMemModel {
     return result->getObjNode();
   }
 
-  inline InterceptResult interceptFunction(const llvm::Function *F, const llvm::Instruction *callSite) {
+  inline InterceptResult interceptFunction(const llvm::Function *F, const llvm::Instruction * /* callSite */) {
     return {F, InterceptResult::Option::EXPAND_BODY};
   }
 
   // return *true* when the callsite handled by the
   template <typename PT>
-  inline constexpr bool interceptCallSite(const CtxFunction<CtxTy> *caller, const CtxFunction<CtxTy> *callee,
-                                          const llvm::Instruction *callSite) const {
+  inline constexpr bool interceptCallSite(const CtxFunction<CtxTy> * /* caller */,
+                                          const CtxFunction<CtxTy> * /* callee */,
+                                          const llvm::Instruction * /* callSite */) const {
     return false;
   }
 

--- a/src/PointerAnalysis/Models/MemoryModel/FieldSensitive/FSObject.h
+++ b/src/PointerAnalysis/Models/MemoryModel/FieldSensitive/FSObject.h
@@ -56,6 +56,8 @@ class FSObject : public Object<ctx, FSObject<ctx>> {
   FSObject(MemBlock<ctx> *memBlock, size_t pOffset, ObjectKind kind = ObjectKind::Normal, bool allowIndex = true)
       : Super(), memBlock(memBlock), pOffset(pOffset), kind(kind), allowIndex(allowIndex){};
 
+  virtual ~FSObject() {}
+
   template <typename PT>
   void initWithNode(ConstraintGraph<ctx> *CG) {
     auto ret = CG->template addCGNode<ObjNode, PT>(this);
@@ -87,7 +89,7 @@ class FSObject : public Object<ctx, FSObject<ctx>> {
     return nullptr;
   }
 
-  virtual bool processSpecial(CGNodeBase<ctx> *src, CGNodeBase<ctx> *dst) const { return false; }
+  virtual bool processSpecial(CGNodeBase<ctx> * /* src */, CGNodeBase<ctx> * /* dst */) const { return false; }
 
   [[nodiscard]] inline const AllocSite<ctx> &getAllocSite() const { return this->memBlock->getAllocSite(); }
 

--- a/src/PointerAnalysis/Program/CtxModule.h
+++ b/src/PointerAnalysis/Program/CtxModule.h
@@ -80,7 +80,7 @@ class CtxModule {
                         .second;  // CtxFunction
       assert(result);
 
-      auto fun = const_cast<CtxFunction<ctx> *>(callNode->getTargetFun());
+      // auto fun = const_cast<CtxFunction<ctx> *>(callNode->getTargetFun());
       // the call node might be an external function
       bool needToExpand = onNewNode(callNode);
       // we should always expand the entry function

--- a/src/PointerAnalysis/Solver/PartialUpdateSolver.h
+++ b/src/PointerAnalysis/Solver/PartialUpdateSolver.h
@@ -48,7 +48,6 @@ class PartialUpdateSolver : public SolverBase<LangModel, PartialUpdateSolver<Lan
     Self &solver;
 
    public:
-
     CallBack(Self &solver, size_t nodeNum) : nodeNum(nodeNum), solver(solver) {}
     virtual ~CallBack() {}
 

--- a/src/PointerAnalysis/Solver/PartialUpdateSolver.h
+++ b/src/PointerAnalysis/Solver/PartialUpdateSolver.h
@@ -49,7 +49,7 @@ class PartialUpdateSolver : public SolverBase<LangModel, PartialUpdateSolver<Lan
 
    public:
     CallBack(Self &solver, size_t nodeNum) : solver(solver), nodeNum(nodeNum) {}
-
+    virtual ~CallBack() {}
     void onNewConstraint(CGNodeTy *src, CGNodeTy *dst, Constraints constraint) override {
       switch (constraint) {
         // copy between globals / parameter passing
@@ -184,7 +184,7 @@ class PartialUpdateSolver : public SolverBase<LangModel, PartialUpdateSolver<Lan
   }
 
   int numOfPTAIterations = 0;
-  void runSolver(LangModel &langModel) {
+  void runSolver(LangModel & /* langModel */) {
     ConsGraphTy &consGraph = *(super::getConsGraph());
 
     do {
@@ -227,7 +227,7 @@ class PartialUpdateSolver : public SolverBase<LangModel, PartialUpdateSolver<Lan
 
       requiredEdge.reset();
 
-      const size_t prevNodeNum = consGraph.getNodeNum();
+      // const size_t prevNodeNum = consGraph.getNodeNum(); // bz: not used, tmp remove this
       int lastID = lsWorkList.find_first_unset();
       while (lastID >= 0) {
         CGNodeTy *curNode = consGraph.getNode(lastID);
@@ -326,7 +326,7 @@ class PartialUpdateSolver : public SolverBase<LangModel, PartialUpdateSolver<Lan
     this->runSolver(*super::getLangModel());
 #else
 
-    int pta_round = 0;
+    // int pta_round = 0;
     bool reanalyze;
     do {
       // after this, the current contraints graph will reach fixed point.

--- a/src/PointerAnalysis/Solver/SolverBase.h
+++ b/src/PointerAnalysis/Solver/SolverBase.h
@@ -179,6 +179,7 @@ class SolverBase {
 
     struct OnNewConstraints : public ConsGraphTy::OnNewConstraintCallBack {
       CallBack &CB;
+      virtual ~OnNewConstraints() {}
       explicit OnNewConstraints(CallBack &CB) : CB(CB) {}
 
       void onNewConstraint(CGNodeTy *src, CGNodeTy *dst, Constraints constraint) override {
@@ -208,7 +209,7 @@ class SolverBase {
 
     bool changed = false;
     for (auto it = PT::begin(dst->getNodeID()), ie = PT::end(dst->getNodeID()); it != ie; it++) {
-      auto tmp = llvm::dyn_cast<ObjNodeTy>(consGraph->getCGNode(*it));
+      // auto tmp = llvm::dyn_cast<ObjNodeTy>(consGraph->getCGNode(*it));
       auto node = consGraph->getObjectNode(*it);
       node = node->getSuperNode();
 

--- a/src/PointerAnalysis/Util/CtxInstVisitor.h
+++ b/src/PointerAnalysis/Util/CtxInstVisitor.h
@@ -135,7 +135,7 @@ class CtxInstVisitor {
   // get called to indicate when transitioning into a new unit.
   //
   void visitFunction(Function &F) {}
-  void visitBasicBlock(BasicBlock &BB) {}
+  void visitBasicBlock(BasicBlock & /* BB */) {}
 
   // Define instruction specific visitor functions that can be overridden to
   // handle SPECIFIC instructions.  These functions automatically define
@@ -295,7 +295,7 @@ class CtxInstVisitor {
   // Note that you MUST override this function if your return type is not
   // void.
   //
-  void visitInstruction(Instruction &I, const ctx *context) {
+  void visitInstruction(Instruction & /* I */, const ctx * /* context */) {
     // llvm::errs() << "unhandled instruction:" << I.getOpcodeName() <<
     // "\n";
   }  // Ignore unhandled instructions
@@ -335,7 +335,7 @@ class CtxInstVisitor {
 
   // An overload that will never actually be called, it is used only from dead
   // code in the dispatching from opcodes to instruction subclasses.
-  RetTy delegateCallInst(Instruction &I, const ctx *context) {
+  RetTy delegateCallInst(Instruction & /* I */, const ctx * /* context */) {
     llvm_unreachable("delegateCallInst called for non-CallInst");
   }
 };


### PR DESCRIPTION
Fix unused-variable, has virtual functions and accessible non-virtual destructor and minor warnings.

Two unused-variable warnings cannot be resolved:
```c
../src/PointerAnalysis/Models/LanguageModel/ConsGraphBuilder.h:245:14: warning: unused variable ‘afterResolve’ [-Wunused-variable]
  245 |       size_t afterResolve = this->getConsGraph()->getNodeNum();
      |              ^~~~~~~~~~~~
../src/PointerAnalysis/Models/LanguageModel/ConsGraphBuilder.h:173:12: warning: unused variable ‘beforeResolve’ [-Wunused-variable]
  173 |     size_t beforeResolve = this->getConsGraph()->getNodeNum();
      |            ^~~~~~~~~~~~~
```
and the source code is like: 
```c
    bool changed = false;
    size_t beforeResolve = this->getConsGraph()->getNodeNum();

    for (NodeID id : funPtrs) {
      ... 
      changed = true; 
      ...
    }
    if (changed) {
      size_t afterResolve = this->getConsGraph()->getNodeNum();
      LOG_DEBUG("PTA Node Stat: Before={}, After={}, New={}", beforeResolve, afterResolve,
                afterResolve - beforeResolve);
    }
```
I've no idea why these are **unused** variables. 