### PR TITLE
Remove new warnings

### DIFF
--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -1,62 +1,60 @@
-#Based on
-#https:  // github.com/lefticus/cpp_starter_project/blob/master/cmake/CompilerWarnings.cmake
+# Based on
+# https://github.com/lefticus/cpp_starter_project/blob/master/cmake/CompilerWarnings.cmake
 
 function(enable_warnings target_name)
 
     set(MSVC_WARNINGS
-        /W4     # Baseline reasonable warnings
-        /w14242 # 'identifier': conversion from 'type1' to 'type1', possible loss of data
-        /w14254 # 'operator': conversion from 'type1:field_bits' to 'type2:field_bits', possible loss of data
-        /w14263 # 'function': member function does not override any base class virtual member function
-        /w14265 # 'classname': class has virtual functions, but destructor is not virtual instances of this class may not
-#be destructed correctly
-        /w14287 # 'operator': unsigned/negative constant mismatch
-        /we4289 # nonstandard extension used: 'variable': loop control variable declared in the for-loop is used outside
-#the for - loop scope
-        /w14296 # 'operator': expression is always 'boolean_value'
-        /w14311 # 'variable': pointer truncation from 'type1' to 'type2'
-        /w14545 # expression before comma evaluates to a function which is missing an argument list
-        /w14546 # function call before comma missing argument list
-        /w14547 # 'operator': operator before comma has no effect; expected operator with side-effect
-        /w14549 # 'operator': operator before comma has no effect; did you intend 'operator'?
-        /w14555 # expression has no effect; expected expression with side- effect
-        /w14619 # pragma warning: there is no warning number 'number'
-        /w14640 # Enable warning on thread un-safe static member initialization
-        /w14826 # Conversion from 'type1' to 'type_2' is sign-extended. This may cause unexpected runtime behavior.
-        /w14905 # wide string literal cast to 'LPSTR'
-        /w14906 # string literal cast to 'LPWSTR'
-        /w14928 # illegal copy-initialization; more than one user-defined conversion has been implicitly applied
-        /permissive- # standards conformance mode for MSVC compiler.
-    )
+            /W4     # Baseline reasonable warnings
+            /w14242 # 'identifier': conversion from 'type1' to 'type1', possible loss of data
+            /w14254 # 'operator': conversion from 'type1:field_bits' to 'type2:field_bits', possible loss of data
+            /w14263 # 'function': member function does not override any base class virtual member function
+            /w14265 # 'classname': class has virtual functions, but destructor is not virtual instances of this class may not
+            # be destructed correctly
+            /w14287 # 'operator': unsigned/negative constant mismatch
+            /we4289 # nonstandard extension used: 'variable': loop control variable declared in the for-loop is used outside
+            # the for-loop scope
+            /w14296 # 'operator': expression is always 'boolean_value'
+            /w14311 # 'variable': pointer truncation from 'type1' to 'type2'
+            /w14545 # expression before comma evaluates to a function which is missing an argument list
+            /w14546 # function call before comma missing argument list
+            /w14547 # 'operator': operator before comma has no effect; expected operator with side-effect
+            /w14549 # 'operator': operator before comma has no effect; did you intend 'operator'?
+            /w14555 # expression has no effect; expected expression with side- effect
+            /w14619 # pragma warning: there is no warning number 'number'
+            /w14640 # Enable warning on thread un-safe static member initialization
+            /w14826 # Conversion from 'type1' to 'type_2' is sign-extended. This may cause unexpected runtime behavior.
+            /w14905 # wide string literal cast to 'LPSTR'
+            /w14906 # string literal cast to 'LPWSTR'
+            /w14928 # illegal copy-initialization; more than one user-defined conversion has been implicitly applied
+            /permissive- # standards conformance mode for MSVC compiler.
+            )
 
     set(CLANG_WARNINGS
-        -Wall
-        -Wextra # reasonable and standard
-#- Wshadow #warn the user if a variable declaration shadows one from a parent context
-        -Wnon-virtual-dtor # warn the user if a class with virtual functions has a non-virtual destructor.
-        -Wold-style-cast # warn for c-style casts
-        -Wcast-align # warn for potential performance problem casts
-        -Wunused # warn on anything being unused
-        -Woverloaded-virtual # warn if you overload (not override) a virtual function
-        -Wpedantic # warn if non-standard C++ is used
-#- Wconversion #warn on type conversions that may lose data                                                      \
-    ->TODO : a lot warnings exists in / src / PointerAnalysis / Models / MemoryModel / FieldSensitive / Layout / \
-    MemLayout.h
-        -Wsign-conversion # warn on sign conversions
-        -Wnull-dereference # warn if a null dereference is detected
-        -Wdouble-promotion # warn if float is implicit promoted to double
-        -Wformat=2 # warn on security issues around functions that format output (ie printf)
-        -Wno-unused-parameter # remove unused parameter warnings
-    )
+            -Wall
+            -Wextra # reasonable and standard
+            # -Wshadow # warn the user if a variable declaration shadows one from a parent context
+            -Wnon-virtual-dtor # warn the user if a class with virtual functions has a non-virtual destructor.
+            -Wold-style-cast # warn for c-style casts
+            -Wcast-align # warn for potential performance problem casts
+            -Wunused # warn on anything being unused
+            -Woverloaded-virtual # warn if you overload (not override) a virtual function
+            -Wpedantic # warn if non-standard C++ is used
+            # -Wconversion # warn on type conversions that may lose data  -> TODO: a lot warnings exists in /src/PointerAnalysis/Models/MemoryModel/FieldSensitive/Layout/MemLayout.h
+            -Wsign-conversion # warn on sign conversions
+            -Wnull-dereference # warn if a null dereference is detected
+            -Wdouble-promotion # warn if float is implicit promoted to double
+            -Wformat=2 # warn on security issues around functions that format output (ie printf)
+            -Wno-unused-parameter # remove unused parameter warnings
+            )
 
     set(GCC_WARNINGS
-        ${CLANG_WARNINGS}
-        -Wmisleading-indentation # warn if indentation implies blocks where blocks do not exist
-        -Wduplicated-cond # warn if if / else chain has duplicated conditions
-        -Wduplicated-branches # warn if if / else branches have duplicated code
-        -Wlogical-op # warn about logical operations being used where bitwise were probably wanted
-#- Wuseless - cast #warn if you perform a cast to the same type
-    )
+            ${CLANG_WARNINGS}
+            -Wmisleading-indentation # warn if indentation implies blocks where blocks do not exist
+            -Wduplicated-cond # warn if if / else chain has duplicated conditions
+            -Wduplicated-branches # warn if if / else branches have duplicated code
+            -Wlogical-op # warn about logical operations being used where bitwise were probably wanted
+            # -Wuseless-cast # warn if you perform a cast to the same type
+            )
 
     if(MSVC)
         set(PROJECT_WARNINGS ${MSVC_WARNINGS})

--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -1,5 +1,5 @@
-# Based on 
-# https://github.com/lefticus/cpp_starter_project/blob/master/cmake/CompilerWarnings.cmake
+#Based on
+#https:  // github.com/lefticus/cpp_starter_project/blob/master/cmake/CompilerWarnings.cmake
 
 function(enable_warnings target_name)
 
@@ -9,10 +9,10 @@ function(enable_warnings target_name)
         /w14254 # 'operator': conversion from 'type1:field_bits' to 'type2:field_bits', possible loss of data
         /w14263 # 'function': member function does not override any base class virtual member function
         /w14265 # 'classname': class has virtual functions, but destructor is not virtual instances of this class may not
-                # be destructed correctly
+#be destructed correctly
         /w14287 # 'operator': unsigned/negative constant mismatch
         /we4289 # nonstandard extension used: 'variable': loop control variable declared in the for-loop is used outside
-                # the for-loop scope
+#the for - loop scope
         /w14296 # 'operator': expression is always 'boolean_value'
         /w14311 # 'variable': pointer truncation from 'type1' to 'type2'
         /w14545 # expression before comma evaluates to a function which is missing an argument list
@@ -32,18 +32,21 @@ function(enable_warnings target_name)
     set(CLANG_WARNINGS
         -Wall
         -Wextra # reasonable and standard
-        # -Wshadow # warn the user if a variable declaration shadows one from a parent context
+#- Wshadow #warn the user if a variable declaration shadows one from a parent context
         -Wnon-virtual-dtor # warn the user if a class with virtual functions has a non-virtual destructor.
         -Wold-style-cast # warn for c-style casts
         -Wcast-align # warn for potential performance problem casts
         -Wunused # warn on anything being unused
         -Woverloaded-virtual # warn if you overload (not override) a virtual function
         -Wpedantic # warn if non-standard C++ is used
-        # -Wconversion # warn on type conversions that may lose data  -> TODO: a lot warnings exists in /src/PointerAnalysis/Models/MemoryModel/FieldSensitive/Layout/MemLayout.h
+#- Wconversion #warn on type conversions that may lose data                                                      \
+    ->TODO : a lot warnings exists in / src / PointerAnalysis / Models / MemoryModel / FieldSensitive / Layout / \
+    MemLayout.h
         -Wsign-conversion # warn on sign conversions
         -Wnull-dereference # warn if a null dereference is detected
         -Wdouble-promotion # warn if float is implicit promoted to double
         -Wformat=2 # warn on security issues around functions that format output (ie printf)
+        -Wno-unused-parameter # remove unused parameter warnings
     )
 
     set(GCC_WARNINGS
@@ -52,7 +55,7 @@ function(enable_warnings target_name)
         -Wduplicated-cond # warn if if / else chain has duplicated conditions
         -Wduplicated-branches # warn if if / else branches have duplicated code
         -Wlogical-op # warn about logical operations being used where bitwise were probably wanted
-        # -Wuseless-cast # warn if you perform a cast to the same type
+#- Wuseless - cast #warn if you perform a cast to the same type
     )
 
     if(MSVC)

--- a/src/PointerAnalysis/Context/HybridCtx.h
+++ b/src/PointerAnalysis/Context/HybridCtx.h
@@ -97,7 +97,7 @@ template <typename... Args>
 struct hash<pta::HybridCtx<Args...>> {
   template <size_t... N>
   size_t hash_tuple(const pta::HybridCtx<Args...> &wrapper, std::index_sequence<N...> sequence) const {
-    llvm::hash_code code = llvm::hash_combine(((const void *)std::get<N>(wrapper.ctx))...);
+    llvm::hash_code code = llvm::hash_combine(static_cast<const void *>(std::get<N>(wrapper.ctx))...);
     return hash_value(code);
   }
 

--- a/src/PointerAnalysis/Models/LanguageModel/ConsGraphBuilder.h
+++ b/src/PointerAnalysis/Models/LanguageModel/ConsGraphBuilder.h
@@ -170,7 +170,7 @@ class ConsGraphBuilder : public llvm::CtxInstVisitor<ctx, SubClass>, public PtrN
     LOG_DEBUG("PTA resolving indirect function pointers. size={}", funPtrs.count());
 
     bool changed = false;
-    size_t beforeResolve = this->getConsGraph()->getNodeNum();
+    [[maybe_unused]] size_t beforeResolve = this->getConsGraph()->getNodeNum();
 
     for (NodeID id : funPtrs) {
       // in case the node is collapsed
@@ -242,7 +242,7 @@ class ConsGraphBuilder : public llvm::CtxInstVisitor<ctx, SubClass>, public PtrN
       }
     }
     if (changed) {
-      size_t afterResolve = this->getConsGraph()->getNodeNum();
+      [[maybe_unused]] size_t afterResolve = this->getConsGraph()->getNodeNum();
       LOG_DEBUG("PTA Node Stat: Before={}, After={}, New={}", beforeResolve, afterResolve,
                 afterResolve - beforeResolve);
     }
@@ -407,8 +407,8 @@ class ConsGraphBuilder : public llvm::CtxInstVisitor<ctx, SubClass>, public PtrN
     Object<ctx, ObjT>::resetObjectID();
 
     // null and universal object nodes;
-    CGNodeBase<ctx> *nullObj = ALLOCATE(NullObj, module->getLLVMModule());
-    CGNodeBase<ctx> *uniObj = ALLOCATE(UniObj, module->getLLVMModule());
+    [[maybe_unused]] CGNodeBase<ctx> *nullObj = ALLOCATE(NullObj, module->getLLVMModule());
+    [[maybe_unused]] CGNodeBase<ctx> *uniObj = ALLOCATE(UniObj, module->getLLVMModule());
 
     // enable this if you want the special nodes to appear in the points to set
 #ifdef SPECIAL_NODE_IN_PTS

--- a/src/Reporter/Reporter.cpp
+++ b/src/Reporter/Reporter.cpp
@@ -55,7 +55,7 @@ void race::to_json(json &j, const RaceAccess &access) {
   } else {
     llvm_unreachable("The report we serialize to JSON should only include races with valid locations");
   }
-};
+}
 
 bool RaceAccess::operator==(const RaceAccess &other) const { return location == other.location && inst == other.inst; }
 bool RaceAccess::operator!=(const RaceAccess &other) const { return !(*this == other); }
@@ -83,7 +83,7 @@ llvm::raw_ostream &race::operator<<(llvm::raw_ostream &os, const RaceAccess &acc
   return os;
 }
 
-void race::to_json(json &j, const Race &race) { j = json{{"access1", race.first}, {"access2", race.second}}; };
+void race::to_json(json &j, const Race &race) { j = json{{"access1", race.first}, {"access2", race.second}}; }
 
 Report::Report(std::vector<std::pair<const WriteEvent *, const MemAccessEvent *>> racepairs) {
   for (auto const &racepair : racepairs) {

--- a/tests/unit/Analysis/OpenMPAnalysis.test.cpp
+++ b/tests/unit/Analysis/OpenMPAnalysis.test.cpp
@@ -9,6 +9,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#include "Analysis/OpenMPAnalysis.h"
+
 #include <llvm/AsmParser/Parser.h>
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IRReader/IRReader.h>
@@ -18,7 +20,6 @@ limitations under the License.
 #include <catch2/catch.hpp>
 #include <sstream>
 
-#include "Analysis/OpenMPAnalysis.h"
 #include "Trace/ProgramTrace.h"
 
 TEST_CASE("OpenMP inSameTeam Analysis") {
@@ -159,7 +160,9 @@ declare dso_local i32 @__kmpc_single(%struct.ident_t*, i32)
   auto const &threads = program.getThreads();
   REQUIRE(threads.size() == 3);
 
-  auto check_same_team = [&arrayIndexAnalysis](const race::ThreadTrace &t1, const race::ThreadTrace &t2) {
+  // bz: check_same_team and check_not_same_team are really not used anywhere
+  [[maybe_unused]] auto check_same_team = [&arrayIndexAnalysis](const race::ThreadTrace &t1,
+                                                                const race::ThreadTrace &t2) {
     for (auto const &e1 : t1.getEvents()) {
       for (auto const &e2 : t2.getEvents()) {
         CHECK(arrayIndexAnalysis.inSameTeam(e1.get(), e2.get()));
@@ -167,7 +170,8 @@ declare dso_local i32 @__kmpc_single(%struct.ident_t*, i32)
     }
   };
 
-  auto check_not_same_team = [&arrayIndexAnalysis](const race::ThreadTrace &t1, const race::ThreadTrace &t2) {
+  [[maybe_unused]] auto check_not_same_team = [&arrayIndexAnalysis](const race::ThreadTrace &t1,
+                                                                    const race::ThreadTrace &t2) {
     for (auto const &e1 : t1.getEvents()) {
       for (auto const &e2 : t2.getEvents()) {
         CHECK_FALSE(arrayIndexAnalysis.inSameTeam(e1.get(), e2.get()));

--- a/tests/unit/Analysis/OpenMPAnalysis.test.cpp
+++ b/tests/unit/Analysis/OpenMPAnalysis.test.cpp
@@ -160,26 +160,6 @@ declare dso_local i32 @__kmpc_single(%struct.ident_t*, i32)
   auto const &threads = program.getThreads();
   REQUIRE(threads.size() == 3);
 
-  // bz: check_same_team and check_not_same_team are really not used anywhere
-  [[maybe_unused]] auto check_same_team = [&arrayIndexAnalysis](const race::ThreadTrace &t1,
-                                                                const race::ThreadTrace &t2) {
-    for (auto const &e1 : t1.getEvents()) {
-      for (auto const &e2 : t2.getEvents()) {
-        CHECK(arrayIndexAnalysis.inSameTeam(e1.get(), e2.get()));
-      }
-    }
-  };
-
-  [[maybe_unused]] auto check_not_same_team = [&arrayIndexAnalysis](const race::ThreadTrace &t1,
-                                                                    const race::ThreadTrace &t2) {
-    for (auto const &e1 : t1.getEvents()) {
-      for (auto const &e2 : t2.getEvents()) {
-        CHECK_FALSE(arrayIndexAnalysis.inSameTeam(e1.get(), e2.get()));
-      }
-    }
-  };
-  llvm::errs() << program << "\n";
-
   auto const &e11 = program.getEvent(1, 1);
   auto const &e14 = program.getEvent(1, 4);
 


### PR DESCRIPTION
Remove new warnings, use `[[maybe_unused]]` supported since C++17.