### PR TITLE
add cpu profile option

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,6 +52,10 @@ target_include_directories(racedetect-lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 add_executable(openrace main.cpp)
 target_link_libraries(openrace racedetect-lib ${llvm_libs})
 
+if (ENABLE_CPU_PROFILE)
+    target_link_libraries(openrace profiler)
+endif()
+
 if(ENABLE_WARNING)
     enable_warnings(pta)
     enable_warnings(openrace)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,6 +27,9 @@ target_include_directories(tester PRIVATE ${LLVM_INCLUDE_DIRS})
 target_include_directories(tester PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 target_compile_definitions(tester PRIVATE ${LLVM_DEFINITIONS})
 
+if (ENABLE_CPU_PROFILE)
+    target_link_libraries(tester profiler)
+endif ()
 
 file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/testresults)
 catch_discover_tests(tester


### PR DESCRIPTION
Adds an option to link against `libprofiler.so` for CPU profiling.
See more at https://gperftools.github.io/gperftools/cpuprofile.html