### PR TITLE
Use getOrCreatePtrNode instead of getPtrNode

### DIFF
--- a/src/PointerAnalysis/Models/LanguageModel/ConsGraphBuilder.h
+++ b/src/PointerAnalysis/Models/LanguageModel/ConsGraphBuilder.h
@@ -310,10 +310,10 @@ class ConsGraphBuilder : public llvm::CtxInstVisitor<ctx, SubClass>, public PtrN
       // at least they should be pointer at the same time
       assert(formal->getType()->isPointerTy() == actual->getType()->isPointerTy());
       if (actual->getType()->isPointerTy()) {
-        CGNodeTy *aNode = this->getPtrNode(caller->getContext(), actual);
+        CGNodeTy *aNode = this->getOrCreatePtrNode(caller->getContext(), actual);
         // If the actual arguments passed to the resolved indirect call
         // site might be super nodes
-        auto fNode = this->getPtrNode(callee->getContext(), formal);
+        auto fNode = this->getOrCreatePtrNode(callee->getContext(), formal);
         // actual argument is assigned to the formal argument.
         this->consGraph->addConstraints(aNode, fNode, Constraints::copy);
       }
@@ -345,7 +345,7 @@ class ConsGraphBuilder : public llvm::CtxInstVisitor<ctx, SubClass>, public PtrN
 
     if (callee->getFunction()->getReturnType()->isPointerTy() && callsite->getType()->isPointerTy()) {
       auto src = this->getRetNode(callee->getContext(), callee->getFunction());
-      auto dst = this->getPtrNode(caller->getContext(), callsite);
+      auto dst = this->getOrCreatePtrNode(caller->getContext(), callsite);
       consGraph->addConstraints(src, dst, Constraints::copy);
     }
   }


### PR DESCRIPTION
Fix the crash of issue #204, but expose new unhandled omp task-related functions for DRB100, DRB101.