### PR TITLE
Remove exception handlers

### DIFF
--- a/src/Analysis/OpenMPAnalysis.cpp
+++ b/src/Analysis/OpenMPAnalysis.cpp
@@ -479,19 +479,14 @@ std::vector<Region> getRegions(const ThreadTrace &thread) {
   for (auto const &event : thread.getEvents()) {
     switch (event->getIRInst()->type) {
       case Start: {
-        if (event->getIRInst()->type != IR::Type::OpenMPSingleStart) {
-          assert(!start.has_value() && "encountered two start types in a row");
-        }
+        assert(!start.has_value() && "encountered two start types in a row");
         start = event->getID();
         break;
       }
       case End: {
         assert(start.has_value() && "encountered end type without a matching start type");
         regions.emplace_back(start.value(), event->getID());
-        // hack for kmpc_end_task showing 2ice, must be fixed in general
-        if (event->getIRInst()->type != IR::Type::OpenMPSingleEnd) {
-          start.reset();
-        }
+        start.reset();
         break;
       }
       default:

--- a/src/PreProcessing/Passes/RemoveExceptionHandlerPass.h
+++ b/src/PreProcessing/Passes/RemoveExceptionHandlerPass.h
@@ -11,12 +11,19 @@ limitations under the License.
 
 #pragma once
 
+#include <llvm/IR/PassManager.h>
 #include <llvm/Pass.h>
 
-class RemoveExceptionHandlerPass : public llvm::FunctionPass {
+class RemoveExceptionHandlerPass : public llvm::PassInfoMixin<RemoveExceptionHandlerPass> {
+ public:
+  llvm::PreservedAnalyses run(llvm::Function &F, llvm::FunctionAnalysisManager &FAM);
+  static bool isRequired() { return true; }
+};
+
+class RemoveExceptionHandlerLegacyPass : public llvm::FunctionPass {
  public:
   static char ID;
-  RemoveExceptionHandlerPass() : llvm::FunctionPass(ID) {}
+  RemoveExceptionHandlerLegacyPass() : llvm::FunctionPass(ID) {}
 
   bool runOnFunction(llvm::Function &F) override;
   bool doInitialization(llvm::Module &M) override;

--- a/src/PreProcessing/PreProcessing.cpp
+++ b/src/PreProcessing/PreProcessing.cpp
@@ -33,6 +33,7 @@ limitations under the License.
 #include "PreProcessing/Passes/DuplicateOpenMPForks.h"
 #include "PreProcessing/Passes/LoweringMemCpyPass.h"
 #include "PreProcessing/Passes/OMPConstantPropPass.h"
+#include "PreProcessing/Passes/RemoveExceptionHandlerPass.h"
 
 namespace {
 void markOMPDebugAlwaysInline(llvm::Module &module) {
@@ -92,12 +93,13 @@ void preprocess(llvm::Module &module) {
   mpm.addPass(llvm::AlwaysInlinerPass());
   mpm.addPass(OMPConstantPropPass());
 
-  // CanonicalizeGEPPass has to run after OMPConstantPropPass
+  // CanonicalizeGEPPass and RemoveExceptionHandlerPass has to run after OMPConstantPropPass
   // as it will expand constant expression
   // but is it the right way to do it like this?
   // or we can simply make it a module pass?
   // or simply call a function just like duplicateOpenMPForks below?
   llvm::FunctionPassManager fpmPost;
+  fpmPost.addPass(RemoveExceptionHandlerPass());
   fpmPost.addPass(CanonicalizeGEPPass());
   mpm.addPass(llvm::createModuleToFunctionPassAdaptor(std::move(fpmPost)));
 


### PR DESCRIPTION
This should remove the need for the OpenMP single "hack".

Before the IR looked something like:

```llvm
start:
  single_start
  ...

end:
  single_end

exception:
  single_end
```

which caused two `single_end`s to be encountered in a row.
removing the exception handling should resolve this.