### PR TITLE
Fix crash caused by mismatched types in omp constant propogation

### DIFF
--- a/tests/integration/dataracebench.test.cpp
+++ b/tests/integration/dataracebench.test.cpp
@@ -103,7 +103,10 @@ TEST_CASE("dataracebench", "[integration][dataracebench][omp]") {
       // 52 indirect array
       Oracle("DRB053-inneronly1-orig-no.ll", {}),  // multi-dimen array
       Oracle("DRB054-inneronly2-orig-no.ll", {}),  // multi-dimen array
-      // 55-58 complex array access
+      Oracle("DRB055-jacobi2d-parallel-no.ll", {}),
+      Oracle("DRB056-jacobi2d-tile-no.ll", {}),
+      Oracle("DRB057-jacobiinitialize-orig-no.ll", {}),
+      Oracle("DRB058-jacobikernel-orig-no.ll", {}),
       // 59 FP caused by last private??
       Oracle("DRB060-matrixmultiply-orig-no.ll", {}),
       Oracle("DRB061-matrixvector1-orig-no.ll", {}),


### PR DESCRIPTION
An assertion failed in LLVM because we were trying to replace a value with a constant of a different type.

```llvm
; consant
@relax = global double ...

; Instruction
load i64, i64* bitcast (double* @relax to i64*)
```

We tried to replace all usages of the above instruction (type `i64`) with the constant value of `relax` (type `double`).

This PR tries to convert the constant to the correct type if there is a mismatch.

closes #182 and #237