### PR TITLE
remodel trace update

### DIFF
--- a/src/Trace/ProgramTrace.cpp
+++ b/src/Trace/ProgramTrace.cpp
@@ -23,9 +23,13 @@ ProgramTrace::ProgramTrace(llvm::Module *module, llvm::StringRef entryName) : mo
   // Run pointer analysis
   pta.analyze(module, entryName);
 
+  TraceBuildState state;
+
   // build all threads starting from this main func
-  auto mainEntry = pta::GT::getEntryNode(pta.getCallGraph());
-  pState.threads.insert(pState.threads.begin(), std::make_unique<ThreadTrace>(*this, mainEntry, pState, tmpState));
+  auto const mainEntry = pta::GT::getEntryNode(pta.getCallGraph());
+  auto mainThread = std::make_unique<ThreadTrace>(*this, mainEntry, state);
+  // insert at front because main thread is always first
+  threads.insert(threads.begin(), std::move(mainThread));
 }
 
 llvm::raw_ostream &race::operator<<(llvm::raw_ostream &os, const ProgramTrace &trace) {

--- a/src/Trace/ProgramTrace.h
+++ b/src/Trace/ProgramTrace.h
@@ -20,31 +20,24 @@ limitations under the License.
 namespace race {
 
 // all included states are ONLY used when building ProgramTrace/ThreadTrace
-struct TmpState {
+struct TraceBuildState {
   // the counter of thread id: since we are constructing ThreadTrace while building events,
   // pState.threads.size() will be updated after finishing the construction, we need such a counter
-  ThreadID currentTID;
-};
-
-// all included states are used for building ProgramTrace and ThreadTrace, and will be used in other constructions
-struct ProgramState {
-  // all threads in the program
-  std::vector<std::unique_ptr<ThreadTrace>> threads;
+  ThreadID currentTID = 0;
 };
 
 class ProgramTrace {
   llvm::Module *module;
-  TmpState tmpState{
-      .currentTID = 0,
-  };
-  ProgramState pState;
+  std::vector<std::unique_ptr<ThreadTrace>> threads;
+
+  friend class ThreadTrace;
 
  public:
   pta::PTA pta;
 
-  [[nodiscard]] inline const std::vector<std::unique_ptr<ThreadTrace>> &getThreads() const { return pState.threads; }
+  [[nodiscard]] inline const std::vector<std::unique_ptr<ThreadTrace>> &getThreads() const { return threads; }
 
-  [[nodiscard]] const Event *getEvent(ThreadID tid, EventID eid) { return pState.threads.at(tid)->getEvent(eid); }
+  [[nodiscard]] const Event *getEvent(ThreadID tid, EventID eid) { return threads.at(tid)->getEvent(eid); }
 
   // Get the module after preprocessing has been run
   [[nodiscard]] const Module &getModule() const { return *module; }

--- a/src/Trace/ThreadTrace.h
+++ b/src/Trace/ThreadTrace.h
@@ -19,8 +19,7 @@ limitations under the License.
 
 namespace race {
 
-struct TmpState;
-struct ProgramState;
+struct TraceBuildState;
 class ProgramTrace;
 
 using ThreadID = size_t;
@@ -32,27 +31,24 @@ class ThreadTrace {
   // The fork event that created this thread
   // Optional because main thread does not have a spawn site
   const std::optional<const ForkEvent *> spawnSite;
-  // extra program information from ProgramTrace
-  TmpState &tmpState;
-  ProgramState &pState;
 
   [[nodiscard]] const std::vector<std::unique_ptr<const Event>> &getEvents() const { return events; }
   [[nodiscard]] std::vector<const ForkEvent *> getForkEvents() const;
 
   [[nodiscard]] const Event *getEvent(EventID id) const { return events.at(id).get(); }
 
-  // Constructs the main thread. All others should be built from forkEvent
-  // constructor
-  ThreadTrace(const ProgramTrace &program, const pta::CallGraphNodeTy *entry, ProgramState &pState, TmpState &tmpState);
-  // Construct thread from forkEvent. entry specifies the entry point of the
-  // spawned thread and should be one of the entries from the spawningEvent
-  // entry list
-  ThreadTrace(ThreadID id, const ForkEvent *spawningEvent, const pta::CallGraphNodeTy *entry, ProgramState &pState,
-              TmpState &tmpState);
+  // Constructs the main thread.
+  // All others should be built from forkEvent constructor
+  ThreadTrace(ProgramTrace &program, const pta::CallGraphNodeTy *entry, TraceBuildState &state);
+  // Construct thread from forkEvent.
+  // entry specifies the entry point of the spawned thread
+  //  and should be one of the entries from the spawningEvent entry list
+  // threads should be mutable reference to ProgramTrace's list of threads
+  ThreadTrace(const ForkEvent *spawningEvent, const pta::CallGraphNodeTy *entry,
+              std::vector<std::unique_ptr<ThreadTrace>> &threads, TraceBuildState &state);
   ~ThreadTrace() = default;
   ThreadTrace(const ThreadTrace &) = delete;
-  ThreadTrace(ThreadTrace &&other) = delete;  // need to update events because they contain reference to parent
-                                              // thread
+  ThreadTrace(ThreadTrace &&other) = delete;
   ThreadTrace &operator=(const ThreadTrace &) = delete;
   ThreadTrace &operator=(ThreadTrace &&other) = delete;
 


### PR DESCRIPTION
Some minor changes.

First one puts any permanent state into the `ProgramTrace` itself so that it can be viewed by analyses after `ProgramTrace` is constructed.

Second change makes the temporary state needed for constructing `ProgramTrace` into a temporary object on the stack that is destroyed after the traces are constructed.

Third change preserves the ordering of the threads in the `ProgramTrace` and fixes a bug I encountered in pushing threads to then`threads` vector.

```cpp
pState.threads.insert(pState.threads.begin(), std::make_unique<ThreadTrace>(*this, mainEntry, pState, tmpState));
```

Previously, `pState.threads.begin()` would execute and get the iterator to the start of the vector before `std::make_unique<ThreadTrace>(...)` which recursively builds threads and adds them to the vector.

If enough threads were added the vector would be resized and the previously obtained iterator was no longer valid.
When the actual insertion was done the program would crash.

Now the code gets the iterator after constructing all the other threads.