### PR TITLE
Threadprivate fix

### DIFF
--- a/src/Analysis/ThreadLocalAnalysis.cpp
+++ b/src/Analysis/ThreadLocalAnalysis.cpp
@@ -16,12 +16,12 @@ using namespace race;
 bool ThreadLocalAnalysis::isThreadLocalAccess(const MemAccessEvent *write, const MemAccessEvent *other) {
   // Get the intersection of the pts to set and
   // check that each obj in the intersection is a thread local value
-  
+
   // This handles cases where given to accesses with pts to sets like
   // write: { O1, O2 }
   // other: { O1, O3 }
   // where O1 is the onlt thread local object
-  
+
   // We should not report a race because the only possible
   // shared object is thread local.
 

--- a/src/Analysis/ThreadLocalAnalysis.cpp
+++ b/src/Analysis/ThreadLocalAnalysis.cpp
@@ -1,0 +1,37 @@
+/* Copyright 2021 Coderrect Inc. All Rights Reserved.
+Licensed under the GNU Affero General Public License, version 3 or later (“AGPL”), as published by the Free Software
+Foundation. You may not use this file except in compliance with the License. You may obtain a copy of the License at
+https://www.gnu.org/licenses/agpl-3.0.en.html
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an “AS IS” BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "Analysis/ThreadLocalAnalysis.h"
+
+using namespace race;
+
+bool ThreadLocalAnalysis::isThreadLocalAccess(const MemAccessEvent *write, const MemAccessEvent *other) {
+  // Get the intersection of the pts to set and
+  // check that each obj in the intersection is a thread local value
+
+  auto writePtsTo = write->getAccessedMemory();
+  auto otherPtsTo = other->getAccessedMemory();
+
+  std::sort(writePtsTo.begin(), writePtsTo.end());
+  std::sort(otherPtsTo.begin(), otherPtsTo.end());
+
+  std::vector<const pta::ObjTy *> shared;
+  std::set_intersection(writePtsTo.begin(), writePtsTo.end(), otherPtsTo.begin(), otherPtsTo.end(),
+                        std::back_inserter(shared));
+
+  return std::all_of(shared.begin(), shared.end(), [](const pta::ObjTy *obj) {
+    auto const val = obj->getValue();
+
+    auto const global = llvm::dyn_cast_or_null<llvm::GlobalVariable>(val);
+    llvm::outs() << *val << " " << (global && global->isThreadLocal()) << "\n";
+    return global && global->isThreadLocal();
+  });
+}

--- a/src/Analysis/ThreadLocalAnalysis.cpp
+++ b/src/Analysis/ThreadLocalAnalysis.cpp
@@ -16,6 +16,14 @@ using namespace race;
 bool ThreadLocalAnalysis::isThreadLocalAccess(const MemAccessEvent *write, const MemAccessEvent *other) {
   // Get the intersection of the pts to set and
   // check that each obj in the intersection is a thread local value
+  
+  // This handles cases where given to accesses with pts to sets like
+  // write: { O1, O2 }
+  // other: { O1, O3 }
+  // where O1 is the onlt thread local object
+  
+  // We should not report a race because the only possible
+  // shared object is thread local.
 
   auto writePtsTo = write->getAccessedMemory();
   auto otherPtsTo = other->getAccessedMemory();

--- a/src/Analysis/ThreadLocalAnalysis.cpp
+++ b/src/Analysis/ThreadLocalAnalysis.cpp
@@ -20,7 +20,7 @@ bool ThreadLocalAnalysis::isThreadLocalAccess(const MemAccessEvent *write, const
   // This handles cases where given to accesses with pts to sets like
   // write: { O1, O2 }
   // other: { O1, O3 }
-  // where O1 is the onlt thread local object
+  // where O1 is the only thread local object
 
   // We should not report a race because the only possible
   // shared object is thread local.
@@ -28,6 +28,7 @@ bool ThreadLocalAnalysis::isThreadLocalAccess(const MemAccessEvent *write, const
   auto writePtsTo = write->getAccessedMemory();
   auto otherPtsTo = other->getAccessedMemory();
 
+  // Must be sorted to do set_intersection
   std::sort(writePtsTo.begin(), writePtsTo.end());
   std::sort(otherPtsTo.begin(), otherPtsTo.end());
 
@@ -39,7 +40,6 @@ bool ThreadLocalAnalysis::isThreadLocalAccess(const MemAccessEvent *write, const
     auto const val = obj->getValue();
 
     auto const global = llvm::dyn_cast_or_null<llvm::GlobalVariable>(val);
-    llvm::outs() << *val << " " << (global && global->isThreadLocal()) << "\n";
     return global && global->isThreadLocal();
   });
 }

--- a/src/Analysis/ThreadLocalAnalysis.h
+++ b/src/Analysis/ThreadLocalAnalysis.h
@@ -1,0 +1,21 @@
+/* Copyright 2021 Coderrect Inc. All Rights Reserved.
+Licensed under the GNU Affero General Public License, version 3 or later (“AGPL”), as published by the Free Software
+Foundation. You may not use this file except in compliance with the License. You may obtain a copy of the License at
+https://www.gnu.org/licenses/agpl-3.0.en.html
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an “AS IS” BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include "Trace/Event.h"
+
+namespace race {
+struct ThreadLocalAnalysis {
+  // return true if all shared objects between the two accesses are thread local
+  bool isThreadLocalAccess(const MemAccessEvent *write, const MemAccessEvent *other);
+};
+}  // namespace race

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,6 +37,7 @@ set(racedetect-lib-sources
     Analysis/SharedMemory.cpp
     Analysis/OpenMPAnalysis.cpp
     Analysis/SimpleAlias.cpp
+    Analysis/ThreadLocalAnalysis.cpp
     IR/Builder.cpp
     IR/IR.cpp
     Trace/Event.cpp

--- a/src/IR/Builder.cpp
+++ b/src/IR/Builder.cpp
@@ -28,10 +28,10 @@ namespace {
 
 // return true if the operand of inst must be a thread local object
 bool flowsFromThreadLocalOperand(const llvm::Instruction *inst) {
-  std::vector<const llvm::Value*> worklist;
+  std::vector<const llvm::Value *> worklist;
   worklist.push_back(llvm::getPointerOperand(inst));
 
-  while(!worklist.empty()) {
+  while (!worklist.empty()) {
     auto val = worklist.back();
     worklist.pop_back();
 
@@ -51,7 +51,7 @@ bool flowsFromThreadLocalOperand(const llvm::Instruction *inst) {
 
     // TODO: Are there other instructions that should eb considered?
   }
-  
+
   return false;
 }
 

--- a/tests/data/integration/openmp/threadlocal-no.c
+++ b/tests/data/integration/openmp/threadlocal-no.c
@@ -1,0 +1,33 @@
+#include <stdio.h>
+#include <omp.h>
+
+struct Data {
+    int x;
+    int y;
+};
+
+struct Data data;
+#pragma omp threadprivate(data)
+
+
+int main() {
+    int x = 0;
+    int y = 0;
+
+    #pragma omp parallel
+    {
+        data.x = omp_get_thread_num();
+        data.y = data.x;
+
+        #pragma omp single nowait
+        {
+            x = data.x;
+        }
+        #pragma omp single
+        {
+            y = data.y;
+        }
+    }
+
+    printf("%d %d\n", x, y);
+}

--- a/tests/integration/dataracebench.test.cpp
+++ b/tests/integration/dataracebench.test.cpp
@@ -252,7 +252,7 @@ TEST_CASE("dataracebench", "[integration][dataracebench][omp]") {
       // 165-168 cannot be built
       // 169 multi-dimen array // Missed TP
       Oracle("DRB170-nestedloops-orig-no.ll", {}),
-      // 171 threadprivate FP
+      Oracle("DRB171-threadprivate3-orig-no.ll", {}),
       Oracle("DRB172-critical2-orig-no.ll", {}),
   };
 

--- a/tests/integration/openmp.test.cpp
+++ b/tests/integration/openmp.test.cpp
@@ -95,3 +95,10 @@ TEST_CASE("OpenMP lastprivate", "[integration][omp]") {
   };
   checkOracles(oracles, "integration/openmp/");
 }
+
+TEST_CASE("OpenMP threadlocal", "[integration][omp]") {
+  std::vector<Oracle> oracles = {
+      Oracle("threadlocal-no.ll", {}),
+  };
+  checkOracles(oracles, "integration/openmp/");
+}


### PR DESCRIPTION
Closes #254 

Add some logic to the threadprivate check to see if the pointer being operated on flows from a global threadlocal object.