### PR TITLE
[DOC] add instruction to enable clang and openmp

### DIFF
--- a/website/docs/doc-setup-dev-env.md
+++ b/website/docs/doc-setup-dev-env.md
@@ -93,7 +93,7 @@ We only build for the X86 platform to save time
 OpenRace is also using C++17
 - `CMAKE_BUILD_TYPE=Release`  
 Builds LLVM in Release mode; use Debug instead to make debugging easier
-- `DLLVM_ENABLE_PROJECTS='clang;openmp'`  
+- `LLVM_ENABLE_PROJECTS='clang;openmp'`  
 Builds clang-10.0.1 and OpenMP together with LLVM; they are required for building test cases
 - `-G Ninja`  
 Building using Ninja Build

--- a/website/docs/doc-setup-dev-env.md
+++ b/website/docs/doc-setup-dev-env.md
@@ -93,8 +93,8 @@ We only build for the X86 platform to save time
 OpenRace is also using C++17
 - `CMAKE_BUILD_TYPE=Release`  
 Builds LLVM in Release mode; use Debug instead to make debugging easier
-- `DLLVM_ENABLE_PROJECTS='clang;openmp'`
-Builds clang-10 and OpenMP together with LLVM; they are needed for building test cases
+- `DLLVM_ENABLE_PROJECTS='clang;openmp'`  
+Builds clang-10.0.1 and OpenMP together with LLVM; they are required for building test cases
 - `-G Ninja`  
 Building using Ninja Build
 

--- a/website/docs/doc-setup-dev-env.md
+++ b/website/docs/doc-setup-dev-env.md
@@ -73,6 +73,7 @@ cmake \
     -DLLVM_OPTIMIZED_TABLEGEN=ON \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX=install \
+    -DLLVM_ENABLE_PROJECTS='clang;openmp' \
     -G Ninja \
     ../llvm
 # Build and Install
@@ -92,6 +93,8 @@ We only build for the X86 platform to save time
 OpenRace is also using C++17
 - `CMAKE_BUILD_TYPE=Release`  
 Builds LLVM in Release mode; use Debug instead to make debugging easier
+- `DLLVM_ENABLE_PROJECTS='clang;openmp'`
+Builds clang-10 and OpenMP together with LLVM; they are needed for building test cases
 - `-G Ninja`  
 Building using Ninja Build
 


### PR DESCRIPTION
Since we removed all ll files from the repository and build them together with the whole project.

Clang-10.0.1 and OpenMP need to be enabled as well when building LLVM.

Otherwise, users will encounter errors like:
> fatal error: 'omp.h' file not found