### PR TITLE
Merge Block and Region into one class

### DIFF
--- a/src/Analysis/OpenMPAnalysis.h
+++ b/src/Analysis/OpenMPAnalysis.h
@@ -21,30 +21,23 @@ namespace race {
 struct Region {
   EventID start;
   EventID end;
+  const ThreadTrace& thread;
 
-  Region(EventID start, EventID end) : start(start), end(end){};
-
-  inline bool contains(EventID e) const { return end >= e && e >= start; }
-};
-
-struct Block {
-  EventID start;
-  EventID end;
-  const ThreadTrace& thread;  // the thread that contains the region
-
-  Block(EventID start, EventID end, const ThreadTrace& thread) : start(start), end(end), thread(thread){};
+  Region(EventID start, EventID end, const ThreadTrace& thread) : start(start), end(end), thread(thread){};
+  Region(const Region&) = default;
 
   inline bool contains(EventID e) const { return end >= e && e >= start; }
 
-  bool operator==(const Block& block) const {
-    auto const blockStartInst = block.thread.getEvent(block.start)->getInst();
-    auto const blockEndInst = block.thread.getEvent(block.end)->getInst();
-    auto const thisStartInst = thread.getEvent(start)->getInst();
-    auto const thisEndInst = thread.getEvent(end)->getInst();
-    return (start == block.start) && (end == block.end) && thisStartInst == blockStartInst &&
-           thisEndInst == blockEndInst;
+  friend bool operator==(const Region& lhs, const Region& rhs) {
+    auto const rhsStartInst = rhs.thread.getEvent(rhs.start)->getInst();
+    auto const rhsEndInst = rhs.thread.getEvent(rhs.end)->getInst();
+    auto const lhsStartInst = lhs.thread.getEvent(lhs.start)->getInst();
+    auto const lhsEndInst = lhs.thread.getEvent(lhs.end)->getInst();
+    return (lhs.start == rhs.start) && (lhs.end == rhs.end) && lhsStartInst == rhsStartInst && lhsEndInst == rhsEndInst;
   }
 };
+
+bool operator==(const Region& lhs, const Region& rhs);
 
 class ReduceAnalysis {
   using ReduceInst = const llvm::Instruction*;

--- a/src/Analysis/OpenMPAnalysis.h
+++ b/src/Analysis/OpenMPAnalysis.h
@@ -24,20 +24,20 @@ struct Region {
   const ThreadTrace& thread;
 
   Region(EventID start, EventID end, const ThreadTrace& thread) : start(start), end(end), thread(thread){};
-  Region(const Region&) = default;
 
   inline bool contains(EventID e) const { return end >= e && e >= start; }
 
-  friend bool operator==(const Region& lhs, const Region& rhs) {
-    auto const rhsStartInst = rhs.thread.getEvent(rhs.start)->getInst();
-    auto const rhsEndInst = rhs.thread.getEvent(rhs.end)->getInst();
-    auto const lhsStartInst = lhs.thread.getEvent(lhs.start)->getInst();
-    auto const lhsEndInst = lhs.thread.getEvent(lhs.end)->getInst();
-    return (lhs.start == rhs.start) && (lhs.end == rhs.end) && lhsStartInst == rhsStartInst && lhsEndInst == rhsEndInst;
-  }
-};
+  // Return true of the other region is the same region in the IR
+  bool sameAs(const Region& other) const {
+    // Quickly check if the size of both regions match
+    if ((end - start) != (other.end - other.start)) return false;
 
-bool operator==(const Region& lhs, const Region& rhs);
+    auto const getInst = [](EventID eid, const ThreadTrace& thread) { return thread.getEvent(eid)->getInst(); };
+
+    return getInst(start, thread) == getInst(other.start, other.thread) &&
+           getInst(end, thread) == getInst(other.end, other.thread);
+  }
+};  // namespace race
 
 class ReduceAnalysis {
   using ReduceInst = const llvm::Instruction*;

--- a/src/Analysis/OpenMPAnalysis.h
+++ b/src/Analysis/OpenMPAnalysis.h
@@ -35,6 +35,15 @@ struct Block {
   Block(EventID start, EventID end, const ThreadTrace& thread) : start(start), end(end), thread(thread){};
 
   inline bool contains(EventID e) const { return end >= e && e >= start; }
+
+  bool operator==(const Block& block) const {
+    auto const blockStartInst = block.thread.getEvent(block.start)->getInst();
+    auto const blockEndInst = block.thread.getEvent(block.end)->getInst();
+    auto const thisStartInst = thread.getEvent(start)->getInst();
+    auto const thisEndInst = thread.getEvent(end)->getInst();
+    return (start == block.start) && (end == block.end) && thisStartInst == blockStartInst &&
+           thisEndInst == blockEndInst;
+  }
 };
 
 class ReduceAnalysis {


### PR DESCRIPTION
Added thread reference to Region so that we don't need the block and region class (just region).

Also changed the (formerly called) `getBlockFor` function to return an optional instead of a pointer so that we don't call `new` directly.