### PR TITLE
Single region tasks on one thread only

### DIFF
--- a/src/Analysis/OpenMPAnalysis.h
+++ b/src/Analysis/OpenMPAnalysis.h
@@ -29,9 +29,6 @@ struct Region {
 
   // Return true of the other region is the same region in the IR
   bool sameAs(const Region& other) const {
-    // Quickly check if the size of both regions match
-    if ((end - start) != (other.end - other.start)) return false;
-
     auto const getInst = [](EventID eid, const ThreadTrace& thread) { return thread.getEvent(eid)->getInst(); };
 
     return getInst(start, thread) == getInst(other.start, other.thread) &&

--- a/src/RaceDetect.cpp
+++ b/src/RaceDetect.cpp
@@ -39,6 +39,10 @@ Report race::detectRaces(llvm::Module *module, DetectRaceConfig config) {
     }
   }
 
+  if (config.printTrace) {
+    llvm::outs() << program << "\n";
+  }
+
   race::SharedMemory sharedmem(program);
   race::HappensBeforeGraph happensbefore(program);
   race::LockSet lockset(program);
@@ -137,10 +141,6 @@ Report race::detectRaces(llvm::Module *module, DetectRaceConfig config) {
         }
       }
     }
-  }
-
-  if (config.printTrace) {
-    llvm::outs() << program << "\n";
   }
 
   if (DEBUG_PTA) {

--- a/src/Trace/ProgramTrace.h
+++ b/src/Trace/ProgramTrace.h
@@ -27,8 +27,9 @@ using OMPStartEnd = std::map<const llvm::CallBase *, const llvm::CallBase *>;
 struct OpenMPState {
   // Track if we are currently in parallel region created from kmpc_fork_teams
   size_t teamsDepth = 0;
-
   bool inTeamsRegion() const { return teamsDepth > 0; }
+
+  bool inSingle = false;
 };
 
 // all included states are ONLY used when building ProgramTrace/ThreadTrace

--- a/src/Trace/ProgramTrace.h
+++ b/src/Trace/ProgramTrace.h
@@ -64,20 +64,17 @@ struct OpenMPState {
 
 // all included states are ONLY used when building ProgramTrace/ThreadTrace
 struct TraceBuildState {
+  // Cached function summaries
   FunctionSummaryBuilder builder;
 
   // the counter of thread id: since we are constructing ThreadTrace while building events,
   // pState.threads.size() will be updated after finishing the construction, we need such a counter
   ThreadID currentTID = 0;
 
-  // the matched master start/end in traverseCallNode
-  const llvm::CallBase *exlMasterStart = nullptr;
-  const llvm::CallBase *exlMasterEnd = nullptr;  // to match skip until
+  // When set, skip traversing until this instruction is reached
+  const llvm::Instruction *skipUntil = nullptr;
 
-  // the matched single(+task) start/end in traverseCallNode
-  const llvm::CallBase *exlSingleStart = nullptr;
-  const llvm::CallBase *exlSingleEnd = nullptr;  // to match skip until
-
+  // Track state specific to OpenMP
   OpenMPState openmp;
 };
 

--- a/src/Trace/ProgramTrace.h
+++ b/src/Trace/ProgramTrace.h
@@ -48,6 +48,18 @@ struct OpenMPState {
   }
   // Get the end of a previously encountered master region
   const llvm::CallBase *getMasterRegionEnd(const llvm::CallBase *start) const { return masterRegions.at(start); }
+
+  // NOTE: this ugliness is only needed because there is no way to get the shared_ptr
+  // from the forkEvent. forkEvent->getIRInst() returns a raw pointer instead.
+  struct UnjoinedTask {
+    const ForkEvent *forkEvent;
+    std::shared_ptr<const OpenMPTask> forkIR;
+
+    UnjoinedTask(const ForkEvent *forkEvent, std::shared_ptr<const OpenMPTask> forkIR)
+        : forkEvent(forkEvent), forkIR(forkIR) {}
+  };
+  // List of unjoined OpenMP task threads
+  std::vector<UnjoinedTask> unjoinedTasks;
 };
 
 // all included states are ONLY used when building ProgramTrace/ThreadTrace
@@ -65,19 +77,6 @@ struct TraceBuildState {
   // the matched single(+task) start/end in traverseCallNode
   const llvm::CallBase *exlSingleStart = nullptr;
   const llvm::CallBase *exlSingleEnd = nullptr;  // to match skip until
-
-  // NOTE: this ugliness is only needed because there is no way to get the shared_ptr
-  // from the forkEvent. forkEvent->getIRInst() returns a raw pointer instead.
-  struct UnjoinedTask {
-    const ForkEvent *forkEvent;
-    std::shared_ptr<const OpenMPTask> forkIR;
-
-    UnjoinedTask(const ForkEvent *forkEvent, std::shared_ptr<const OpenMPTask> forkIR)
-        : forkEvent(forkEvent), forkIR(forkIR) {}
-  };
-
-  // List of unjoined OpenMP task threads
-  std::vector<UnjoinedTask> unjoinedTasks;
 
   OpenMPState openmp;
 };

--- a/src/Trace/ThreadTrace.cpp
+++ b/src/Trace/ThreadTrace.cpp
@@ -103,22 +103,20 @@ bool handleOpenMPMaster(const CallIR *callIR, TraceBuildState &state, bool isMas
   if (callIR->type == IR::Type::OpenMPMasterStart) {
     if (!isMasterThread) {
       // skip on non-master threads
-      auto end = state.find(callIR->getInst());
+      auto end = state.openmp.getMasterRegionEnd(callIR->getInst());
       assert(end && "encountered master start without end");
       state.exlMasterEnd = end;
       return true;
     }
 
     // Save the beggining of the master region
-    assert(!state.exlMasterStart && "encountered two master starts in a row");
-    state.exlMasterStart = callIR->getInst();
+    state.openmp.markMasterStart(callIR->getInst());
     return false;
   }
 
   if (callIR->type == IR::Type::OpenMPMasterEnd && isMasterThread) {
     // Save the end of the master region
-    state.insert(state.exlMasterStart, callIR->getInst());
-    state.exlMasterStart = nullptr;
+    state.openmp.markMasterEnd(callIR->getInst());
   }
 
   return false;

--- a/tests/integration/openmp.test.cpp
+++ b/tests/integration/openmp.test.cpp
@@ -101,10 +101,11 @@ TEST_CASE("OpenMP task", "[integration][omp]") {
       Oracle("task-single-call.ll", {}),
       Oracle("task-single-no.ll", {}),
       Oracle("task-single-yes.ll", {"task-single-yes.c:15:17 task-single-yes.c:21:17"}),
-      Oracle("task-master-single-yes.ll", {"task-master-single-yes.c:18:14 task-master-single-yes.c:14:16"}),
+      Oracle("task-master-single-yes.ll", {"task-master-single-yes.c:18:14 task-master-single-yes.c:14:16",
+                                           "task-master-single-yes.c:14:16 task-master-single-yes.c:18:14"}),
       Oracle("task-tid-no.ll", {"task-tid-no.c:15:16 task-tid-no.c:15:16"}),  // cannot identify if condition
       Oracle("task-yes.ll", {"task-yes.c:13:14 task-yes.c:13:14"}),
-    };
+  };
   checkOracles(oracles, "integration/openmp/");
 }
 


### PR DESCRIPTION
This puts single regions on both threads, but skips spawning tasks if the tasks are in a single region and not on the master thread.

Also moved all the OpenMP related build state to `state.openmp` and replaced the multiple skip instruction flags with a single `skipUntil`. 