### PR TITLE
Implement SIMD

### DIFF
--- a/src/Analysis/OpenMPAnalysis.cpp
+++ b/src/Analysis/OpenMPAnalysis.cpp
@@ -1025,3 +1025,8 @@ bool OpenMPAnalysis::insideCompatibleSections(const Event *event1, const Event *
 
   return false;
 }
+
+bool OpenMPAnalysis::isSameSIMDWrite(const Event *event1, const Event *event2) {
+  return OpenMPModel::isSimdBlock(event1->getInst()->getParent()) && event1->type == Event::Type::Write &&
+         event2->type == Event::Type::Write && event1->getInst() == event2->getInst();
+}

--- a/src/Analysis/OpenMPAnalysis.h
+++ b/src/Analysis/OpenMPAnalysis.h
@@ -138,6 +138,9 @@ class OpenMPAnalysis {
   // return true if both events are in compatible sections
   static bool insideCompatibleSections(const Event* event1, const Event* event2);
 
+  // return true if this is simd and is the same write event
+  static bool isSameSIMDWrite(const Event* event1, const Event* event2);
+
   // return true if both events are gauranteed to execute on the same thread
   // by a check against omp_get_thread_num
   bool guardedBySameTid(const Event* event1, const Event* event2) const {

--- a/src/IR/IR.h
+++ b/src/IR/IR.h
@@ -34,12 +34,14 @@ class IR {
     OpenMPFork,
     OpenMPTaskFork,
     OpenMPForkTeams,
+    OpenMPSIMDFork,
     END_Fork,
     Join,
     PthreadJoin,
     OpenMPJoin,
     OpenMPTaskJoin,
     OpenMPJoinTeams,
+    OpenMPSIMDJoin,
     END_Join,
     Lock,
     PthreadMutexLock,
@@ -146,6 +148,9 @@ class ForkIR : public IR {
   // E.g. for pthread_create(&thread, NULL, foo, NULL)
   // the thread entry is foo
   [[nodiscard]] virtual const llvm::Value *getThreadEntry() const = 0;
+
+  // Get the instruction that the spawned thread will terminate on, if this is a non-function thread start
+  [[nodiscard]] virtual std::optional<const llvm::Value *> getThreadExit() const { return std::nullopt; }
 
   void print(llvm::raw_ostream &os) const override;
 

--- a/src/LanguageModel/OpenMP.h
+++ b/src/LanguageModel/OpenMP.h
@@ -91,6 +91,8 @@ inline bool isUnsetNestLock(const llvm::StringRef& funcName) { return funcName.e
 inline bool isOrderedStart(const llvm::StringRef& funcName) { return funcName.equals("__kmpc_ordered"); }
 inline bool isOrderedEnd(const llvm::StringRef& funcName) { return funcName.equals("__kmpc_end_ordered"); }
 
+// we may discover that this implementation is false positive prone
+// if so, there is no way to reliably identify blocks which should be SIMD without altering LLVM
 inline bool isSimdBlock(const llvm::BasicBlock* block) {
   return !block->getParent()->getName().startswith(".omp_outlined") && block->hasName() &&
          block->getName().startswith("omp.inner.for.body");

--- a/src/LanguageModel/OpenMP.h
+++ b/src/LanguageModel/OpenMP.h
@@ -91,6 +91,11 @@ inline bool isUnsetNestLock(const llvm::StringRef& funcName) { return funcName.e
 inline bool isOrderedStart(const llvm::StringRef& funcName) { return funcName.equals("__kmpc_ordered"); }
 inline bool isOrderedEnd(const llvm::StringRef& funcName) { return funcName.equals("__kmpc_end_ordered"); }
 
+inline bool isSimdBlock(const llvm::BasicBlock* block) {
+  return !block->getParent()->getName().startswith(".omp_outlined") && block->hasName() &&
+         block->getName().startswith("omp.inner.for.body");
+}
+
 // Return true for omp calls that do not need to be modelled (e.g. push_num_threads)
 inline bool isNoEffect(const llvm::StringRef& funcName) {
   return matchesAny(funcName, {"__kmpc_push_num_threads", "__kmpc_global_thread_num", "__kmpc_copyprivate",

--- a/src/RaceDetect.cpp
+++ b/src/RaceDetect.cpp
@@ -104,6 +104,10 @@ Report race::detectRaces(llvm::Module *module, DetectRaceConfig config) {
       // This may miss races according to OpenMP specification,
       //  but will not miss races according to how Clang generates OpenMP code (as of clang 10.0.1)
       if (ompAnalysis.isInLastprivate(write) && ompAnalysis.isInLastprivate(other)) return;
+
+      // SIMD clashing write events are false-positive; this is not a case that will happen because the writes
+      // will be vectorised
+      if (race::OpenMPAnalysis::isSameSIMDWrite(write, other)) return;
     }
 
     // Race detected

--- a/src/RaceDetect.cpp
+++ b/src/RaceDetect.cpp
@@ -105,8 +105,7 @@ Report race::detectRaces(llvm::Module *module, DetectRaceConfig config) {
       //  but will not miss races according to how Clang generates OpenMP code (as of clang 10.0.1)
       if (ompAnalysis.isInLastprivate(write) && ompAnalysis.isInLastprivate(other)) return;
 
-      // SIMD clashing write events are false-positive; this is not a case that will happen because the writes
-      // will be vectorised
+      // SIMD clashing write events are false-positive; this is not a race case because the writes will be vectorised
       if (race::OpenMPAnalysis::isSameSIMDWrite(write, other)) return;
     }
 

--- a/src/Trace/Event.cpp
+++ b/src/Trace/Event.cpp
@@ -14,7 +14,12 @@ limitations under the License.
 using namespace race;
 
 llvm::raw_ostream &race::operator<<(llvm::raw_ostream &os, const Event &event) {
-  os << event.getID() << " " << event.type << "\t" << *event.getInst();
+  os << event.getID() << " " << event.type << "\t";
+  if (event.getInst()) {
+    os << *event.getInst();
+  } else {
+    event.getIRInst()->print(os);
+  }
   return os;
 }
 

--- a/src/Trace/EventImpl.cpp
+++ b/src/Trace/EventImpl.cpp
@@ -35,6 +35,8 @@ std::vector<const pta::CallGraphNodeTy *> ForkEventImpl::getThreadEntry() const 
     auto const entryNode = info->thread.program.pta.getDirectNodeOrNull(newContext, entryFunc);
     return {entryNode};
   } else if (auto entryInst = llvm::dyn_cast<llvm::Instruction>(entryVal)) {
+    // we do NOT evolve the context here because to do so would lead to only negative results
+    // we need the scopes to be the same so that the arrays written to are the same
     auto const newContext = info->context;
     auto const entryNode = info->thread.program.pta.getDirectNodeOrNull(newContext, entryInst->getFunction());
     return {entryNode};

--- a/src/Trace/EventImpl.cpp
+++ b/src/Trace/EventImpl.cpp
@@ -34,8 +34,11 @@ std::vector<const pta::CallGraphNodeTy *> ForkEventImpl::getThreadEntry() const 
     auto const newContext = pta::CT::contextEvolve(info->context, fork->getInst());
     auto const entryNode = info->thread.program.pta.getDirectNodeOrNull(newContext, entryFunc);
     return {entryNode};
+  } else if (auto entryInst = llvm::dyn_cast<llvm::Instruction>(entryVal)) {
+    auto const newContext = info->context;
+    auto const entryNode = info->thread.program.pta.getDirectNodeOrNull(newContext, entryInst->getFunction());
+    return {entryNode};
   }
-
   // the entry is indirect and we need to figure out where the real function is
   auto callsite = info->thread.program.pta.getInDirectCallSite(info->context, fork->getInst());
   auto const &nodes = callsite->getResolvedNode();

--- a/tests/integration/dataracebench.test.cpp
+++ b/tests/integration/dataracebench.test.cpp
@@ -74,9 +74,10 @@ TEST_LL("DRB023", "DRB023-sections1-orig-yes.ll",
         EXPECTED("DRB023-sections1-orig-yes.c:58:7 DRB023-sections1-orig-yes.c:60:7",
                  "DRB023-sections1-orig-yes.c:60:7 DRB023-sections1-orig-yes.c:58:7"))
 
-// DRB 24 and 25 are simd
-// TEST_LL("DRB024", /*TODO*/, EXPECTED(/*TODO*/))
-// TEST_LL("DRB025", /*TODO*/, EXPECTED(/*TODO*/))
+TEST_LL("DRB024", "DRB024-simdtruedep-orig-yes.ll",
+        EXPECTED("DRB024-simdtruedep-orig-yes.c:66:11 DRB024-simdtruedep-orig-yes.c:66:12"))
+TEST_LL("DRB025", "DRB025-simdtruedep-var-yes.ll",
+        EXPECTED("DRB025-simdtruedep-var-yes.c:68:11 DRB025-simdtruedep-var-yes.c:68:12", ))
 
 TEST_LL("DRB026", "DRB026-targetparallelfor-orig-yes.ll",
         EXPECTED("DRB026-targetparallelfor-orig-yes.c:64:9 DRB026-targetparallelfor-orig-yes.c:64:10"))
@@ -146,8 +147,7 @@ TEST_LL("DRB067", "DRB067-restrictpointer1-orig-no.ll", NORACE)
 TEST_LL("DRB068", "DRB068-restrictpointer2-orig-no.ll", NORACE)
 TEST_LL("DRB069", "DRB069-sectionslock1-orig-no.ll", NORACE)
 
-// 70 simd
-// TEST_LL("DRB070", /*TODO*/, EXPECTED(/*TODO*/))
+TEST_LL("DRB070", "DRB070-simd1-orig-no.ll", NORACE)
 
 TEST_LL("DRB071", "DRB071-targetparallelfor-orig-no.ll", NORACE)
 
@@ -249,8 +249,8 @@ TEST_LL("DRB113", "DRB113-default-orig-no.ll", NORACE)
 // 114 omp if
 // TEST_LL("DRB114", /*TODO*/, EXPECTED(/*TODO*/))
 
-// 115 simd
-// TEST_LL("DRB115", /*TODO*/, EXPECTED(/*TODO*/))
+TEST_LL("DRB115", "DRB115-forsimd-orig-yes.ll",
+        EXPECTED("DRB115-forsimd-orig-yes.c:66:11 DRB115-forsimd-orig-yes.c:66:12"))
 
 // 116 target teams
 // TEST_LL("DRB116", /*TODO*/, EXPECTED(/*TODO*/))


### PR DESCRIPTION
This PR should implement SIMD, but only very, very basic cases. I do not think this encompasses them all and I think it may be false negative prone for several cases, but it should catch a majority of actual SIMD which would have actually been vectorised if clang didn't silently fail to do so.

Some comments need adding before this is ready to go.