### PR TITLE
Implement isCompatible in RaceModel.cpp

### DIFF
--- a/src/PreProcessing/Passes/OMPConstantPropPass.cpp
+++ b/src/PreProcessing/Passes/OMPConstantPropPass.cpp
@@ -382,13 +382,17 @@ bool runOpenMPConstantPropagation(Module &M, std::function<const TargetLibraryIn
 
     FunctionChanged = false;
     // propagate constant inside the function and prep next propagation
+    auto worksize = work.size();
     work.clear();
     for (Function *F : changedFunction) {
       const TargetLibraryInfo &TLI = GetTLI(*F);
-      FunctionChanged |= intraConstantProp(*F, TLI);
-      auto userEdgeRange = userEdges.equal_range(F);
-      for (auto userEdgeIter = userEdgeRange.first; userEdgeIter != userEdgeRange.second; userEdgeIter++) {
-        work.insert(userEdgeIter->second);  // these are the only entries which were propagated to
+      auto furtherPropagated = intraConstantProp(*F, TLI);
+      FunctionChanged |= furtherPropagated;
+      if (furtherPropagated) {
+        auto userEdgeRange = userEdges.equal_range(F);
+        for (auto userEdgeIter = userEdgeRange.first; userEdgeIter != userEdgeRange.second; userEdgeIter++) {
+          work.insert(userEdgeIter->second);  // these are the only entries which were propagated to
+        }
       }
     }
 

--- a/src/PreProcessing/Passes/OMPConstantPropPass.cpp
+++ b/src/PreProcessing/Passes/OMPConstantPropPass.cpp
@@ -382,7 +382,6 @@ bool runOpenMPConstantPropagation(Module &M, std::function<const TargetLibraryIn
 
     FunctionChanged = false;
     // propagate constant inside the function and prep next propagation
-    auto worksize = work.size();
     work.clear();
     for (Function *F : changedFunction) {
       const TargetLibraryInfo &TLI = GetTLI(*F);

--- a/src/PreProcessing/Passes/OMPConstantPropPass.cpp
+++ b/src/PreProcessing/Passes/OMPConstantPropPass.cpp
@@ -329,13 +329,13 @@ std::set<Function *> getUserFunctions(Function &F) {
     // If no abstract call site was created we did not understand the use,
     // bail.
     AbstractCallSite ACS(&U);
-    if (!ACS) return {}; // this would be bailed anyways
+    if (!ACS) return {};  // this would be bailed anyways
 
     // Mismatched argument count is undefined behavior. Simply bail out to
     // avoid handling of such situations below (avoiding asserts/crashes).
     unsigned NumActualArgs = ACS.getNumArgOperands();
     if (F.isVarArg() ? F.arg_size() > NumActualArgs : F.arg_size() != NumActualArgs)
-      return {}; // this would be bailed anyways
+      return {};  // this would be bailed anyways
 
     userFunctions.insert(ACS.getInstruction()->getParent()->getParent());
   }
@@ -357,7 +357,6 @@ bool runOpenMPConstantPropagation(Module &M, std::function<const TargetLibraryIn
       userEdges.emplace(userFunction, &F);
     }
   }
-
 
   SmallSet<Function *, 8> work;
   for (auto edge : userEdges) {
@@ -389,7 +388,7 @@ bool runOpenMPConstantPropagation(Module &M, std::function<const TargetLibraryIn
       FunctionChanged |= intraConstantProp(*F, TLI);
       auto userEdgeRange = userEdges.equal_range(F);
       for (auto userEdgeIter = userEdgeRange.first; userEdgeIter != userEdgeRange.second; userEdgeIter++) {
-        work.insert(userEdgeIter->second); // these are the only entries which were propagated to
+        work.insert(userEdgeIter->second);  // these are the only entries which were propagated to
       }
     }
 

--- a/src/PreProcessing/Passes/OMPConstantPropPass.cpp
+++ b/src/PreProcessing/Passes/OMPConstantPropPass.cpp
@@ -317,28 +317,63 @@ bool PropagateConstantsIntoArguments(Function &F, const DominatorTree &DT, const
   return MadeChange;
 }
 
+// we can get a list of function which are users of this function -- if a constant is propagated in a user, we may
+// need to propagate it to used functions, so this method allows us to collect the relevant functions
+std::set<Function *> getUserFunctions(Function &F) {
+  std::set<Function *> userFunctions;
+  for (Use &U : F.uses()) {
+    User *UR = U.getUser();
+    // Ignore blockaddress uses.
+    if (isa<BlockAddress>(UR)) continue;
+
+    // If no abstract call site was created we did not understand the use,
+    // bail.
+    AbstractCallSite ACS(&U);
+    if (!ACS) return {}; // this would be bailed anyways
+
+    // Mismatched argument count is undefined behavior. Simply bail out to
+    // avoid handling of such situations below (avoiding asserts/crashes).
+    unsigned NumActualArgs = ACS.getNumArgOperands();
+    if (F.isVarArg() ? F.arg_size() > NumActualArgs : F.arg_size() != NumActualArgs)
+      return {}; // this would be bailed anyways
+
+    userFunctions.insert(ACS.getInstruction()->getParent()->getParent());
+  }
+  return userFunctions;
+}
+
 bool runOpenMPConstantPropagation(Module &M, std::function<const TargetLibraryInfo &(Function &)> GetTLI,
                                   std::function<const DominatorTree &(Function &)> GetDT) {
   bool Changed = false;
   bool ArgPropagated = true;
   bool FunctionChanged = true;
 
+  std::multimap<Function *, Function *> userEdges;
+
   for (Function &F : M) {
     const TargetLibraryInfo &TLI = GetTLI(F);
-    Changed = intraConstantProp(F, TLI);
+    Changed |= intraConstantProp(F, TLI);
+    for (auto userFunction : getUserFunctions(F)) {
+      userEdges.emplace(userFunction, &F);
+    }
   }
 
+
+  SmallSet<Function *, 8> work;
+  for (auto edge : userEdges) {
+    work.insert(edge.first);
+  }
   // propagate constant into function arguement
   SmallSet<Function *, 8> changedFunction;
   while (FunctionChanged) {
     while (ArgPropagated) {
       ArgPropagated = false;
-      for (Function &F : M) {
-        if (!F.isDeclaration()) {
+      for (Function *F : work) {
+        if (!F->isDeclaration()) {
           // Delete any klingons.
-          F.removeDeadConstantUsers();
-          if (PropagateConstantsIntoArguments(F, GetDT(F), GetTLI(F))) {
-            changedFunction.insert(&F);
+          F->removeDeadConstantUsers();
+          if (PropagateConstantsIntoArguments(*F, GetDT(*F), GetTLI(*F))) {
+            changedFunction.insert(F);
             ArgPropagated = true;
           }
         }
@@ -347,13 +382,18 @@ bool runOpenMPConstantPropagation(Module &M, std::function<const TargetLibraryIn
     }
 
     FunctionChanged = false;
-    // propagate constant inside the function
-    if (!changedFunction.empty()) {
-      for (Function *F : changedFunction) {
-        const TargetLibraryInfo &TLI = GetTLI(*F);
-        FunctionChanged |= intraConstantProp(*F, TLI);
+    // propagate constant inside the function and prep next propagation
+    work.clear();
+    for (Function *F : changedFunction) {
+      const TargetLibraryInfo &TLI = GetTLI(*F);
+      FunctionChanged |= intraConstantProp(*F, TLI);
+      auto userEdgeRange = userEdges.equal_range(F);
+      for (auto userEdgeIter = userEdgeRange.first; userEdgeIter != userEdgeRange.second; userEdgeIter++) {
+        work.insert(userEdgeIter->second); // these are the only entries which were propagated to
       }
     }
+
+    changedFunction.clear();
   }
   return Changed;
 }

--- a/src/PreProcessing/Passes/OMPConstantPropPass.cpp
+++ b/src/PreProcessing/Passes/OMPConstantPropPass.cpp
@@ -342,6 +342,8 @@ std::set<Function *> getUserFunctions(Function &F) {
   return userFunctions;
 }
 
+// TODO fix constant propagation in libraries where exported functions are called called internally as well, leading to
+// false negatives due to incorrect constant propagation
 bool runOpenMPConstantPropagation(Module &M, std::function<const TargetLibraryInfo &(Function &)> GetTLI,
                                   std::function<const DominatorTree &(Function &)> GetDT) {
   bool Changed = false;


### PR DESCRIPTION
Fixed issue #278: Implemented `isCompatible` in `RaceModel.cpp`, no more crash on CovidSim. However, there is a recursive call to create the same thread I guess, and the building of thread trace won't terminate. 