### PR TITLE
ThreadLocal optimisations

### DIFF
--- a/src/Analysis/ThreadLocalAnalysis.cpp
+++ b/src/Analysis/ThreadLocalAnalysis.cpp
@@ -25,12 +25,9 @@ bool ThreadLocalAnalysis::isThreadLocalAccess(const MemAccessEvent *write, const
   // We should not report a race because the only possible
   // shared object is thread local.
 
+  // Guaranteed to be sorted in RaceDetect
   auto writePtsTo = write->getAccessedMemory();
   auto otherPtsTo = other->getAccessedMemory();
-
-  // Must be sorted to do set_intersection
-  std::sort(writePtsTo.begin(), writePtsTo.end());
-  std::sort(otherPtsTo.begin(), otherPtsTo.end());
 
   std::vector<const pta::ObjTy *> shared;
   std::set_intersection(writePtsTo.begin(), writePtsTo.end(), otherPtsTo.begin(), otherPtsTo.end(),

--- a/src/RaceDetect.cpp
+++ b/src/RaceDetect.cpp
@@ -118,6 +118,20 @@ Report race::detectRaces(llvm::Module *module, DetectRaceConfig config) {
     auto threadedWrites = sharedmem.getThreadedWrites(sharedObj);
     auto threadedReads = sharedmem.getThreadedReads(sharedObj);
 
+    // pre-sort accessed memory for reads and writes for thread local analysis
+    for (auto const &thread : threadedWrites) {
+      for (auto const write : thread.second) {
+        auto writePtsTo = write->getAccessedMemory();
+        std::sort(writePtsTo.begin(), writePtsTo.end());
+      }
+    }
+    for (auto const &thread : threadedReads) {
+      for (auto const read : thread.second) {
+        auto readPtsTo = read->getAccessedMemory();
+        std::sort(readPtsTo.begin(), readPtsTo.end());
+      }
+    }
+
     for (auto it = threadedWrites.begin(), end = threadedWrites.end(); it != end; ++it) {
       auto const wtid = it->first;
       auto const writes = it->second;


### PR DESCRIPTION
This pre-sorts (and removes the repeated sorting) of memory access events as required by threadlocal's set intersection.