### PR TITLE
Optimise accessed memory checks

### DIFF
--- a/src/Analysis/ThreadLocalAnalysis.cpp
+++ b/src/Analysis/ThreadLocalAnalysis.cpp
@@ -25,15 +25,8 @@ bool ThreadLocalAnalysis::isThreadLocalAccess(const MemAccessEvent *write, const
   // We should not report a race because the only possible
   // shared object is thread local.
 
-  auto writePtsTo = write->getAccessedMemory();
-  auto otherPtsTo = other->getAccessedMemory();
-
-  // Must be sorted to do set_intersection
-  // this is sorted by pointer value, not by anything to do with the actual memory accesses itself
-  // this oddity is perfectly fine for our purposes since we do not care about order of evaluation, just that we can do
-  // set intersection consistently based on *some* order
-  std::sort(writePtsTo.begin(), writePtsTo.end());
-  std::sort(otherPtsTo.begin(), otherPtsTo.end());
+  const auto &writePtsTo = write->getAccessedMemory();
+  const auto &otherPtsTo = other->getAccessedMemory();
 
   // this is set intersection, but we can fail fast unlike the stl implementation
   // this allows us to have superior speeds in cases that definitely don't involve globals faster since it will just

--- a/src/PointerAnalysis/Solver/SolverBase.h
+++ b/src/PointerAnalysis/Solver/SolverBase.h
@@ -339,7 +339,7 @@ class SolverBase {
     result.push_back(lockStrObjects.at(lockStr)->getObject());
   }
 
-  void getPointsTo(const ctx *context, const llvm::Value *V, std::vector<const ObjTy *> &result) const {
+  void getPointsTo(const ctx *context, const llvm::Value *V, std::multiset<const ObjTy *> &result) const {
     assert(V->getType()->isPointerTy());
 
     // get the node value
@@ -354,7 +354,7 @@ class SolverBase {
       if (objNode->isSpecialNode()) {
         continue;
       }
-      result.push_back(objNode->getObject());
+      result.insert(objNode->getObject());
     }
   }
 

--- a/src/Trace/Event.h
+++ b/src/Trace/Event.h
@@ -56,7 +56,7 @@ class MemAccessEvent : public Event {
 
  public:
   [[nodiscard]] const race::MemAccessIR *getIRInst() const override = 0;
-  [[nodiscard]] virtual std::vector<const pta::ObjTy *> getAccessedMemory() const = 0;
+  [[nodiscard]] virtual const std::multiset<const pta::ObjTy *> &getAccessedMemory() const = 0;
 
   // Used for llvm style RTTI (isa, dyn_cast, etc.)
   [[nodiscard]] static inline bool classof(const Event *e) { return e->type == Type::Read || e->type == Type::Write; }

--- a/src/Trace/EventImpl.cpp
+++ b/src/Trace/EventImpl.cpp
@@ -11,22 +11,11 @@ limitations under the License.
 
 #include "Trace/EventImpl.h"
 
-#include "Trace/ProgramTrace.h"
-#include "Trace/ThreadTrace.h"
-
 using namespace race;
 
-std::vector<const pta::ObjTy *> ReadEventImpl::getAccessedMemory() const {
-  std::vector<const pta::ObjTy *> pts;
-  info->thread.program.pta.getPointsTo(info->context, read->getAccessedValue(), pts);
-  return pts;
-}
+const std::multiset<const pta::ObjTy *> &ReadEventImpl::getAccessedMemory() const { return accessedMemory; }
 
-std::vector<const pta::ObjTy *> WriteEventImpl::getAccessedMemory() const {
-  std::vector<const pta::ObjTy *> pts;
-  info->thread.program.pta.getPointsTo(info->context, write->getAccessedValue(), pts);
-  return pts;
-}
+const std::multiset<const pta::ObjTy *> &WriteEventImpl::getAccessedMemory() const { return accessedMemory; }
 
 std::vector<const pta::CallGraphNodeTy *> ForkEventImpl::getThreadEntry() const {
   auto entryVal = fork->getThreadEntry();

--- a/src/Trace/EventImpl.h
+++ b/src/Trace/EventImpl.h
@@ -13,6 +13,8 @@ limitations under the License.
 
 #include "IR/IR.h"
 #include "Trace/Event.h"
+#include "Trace/ProgramTrace.h"
+#include "Trace/ThreadTrace.h"
 
 // These are implementation of the Event interfaces in Event.h
 
@@ -35,38 +37,44 @@ struct EventInfo {
 
 class ReadEventImpl : public ReadEvent {
   std::shared_ptr<EventInfo> info;
+  std::multiset<const pta::ObjTy *> accessedMemory;
 
  public:
   const std::shared_ptr<const ReadIR> read;
   const EventID id;
 
   ReadEventImpl(std::shared_ptr<const ReadIR> read, std::shared_ptr<EventInfo> info, EventID id)
-      : info(std::move(info)), read(std::move(read)), id(id) {}
+      : info(std::move(info)), read(std::move(read)), id(id), accessedMemory({}) {
+    this->info->thread.program.pta.getPointsTo(this->info->context, this->read->getAccessedValue(), accessedMemory);
+  }
 
   [[nodiscard]] inline EventID getID() const override { return id; }
   [[nodiscard]] inline const pta::ctx *getContext() const override { return info->context; }
   [[nodiscard]] inline const ThreadTrace &getThread() const override { return info->thread; }
   [[nodiscard]] inline const race::ReadIR *getIRInst() const override { return read.get(); }
 
-  [[nodiscard]] std::vector<const pta::ObjTy *> getAccessedMemory() const override;
+  [[nodiscard]] const std::multiset<const pta::ObjTy *> &getAccessedMemory() const override;
 };
 
 class WriteEventImpl : public WriteEvent {
   std::shared_ptr<EventInfo> info;
+  std::multiset<const pta::ObjTy *> accessedMemory;
 
  public:
   const std::shared_ptr<const WriteIR> write;
   const EventID id;
 
   WriteEventImpl(std::shared_ptr<const WriteIR> write, std::shared_ptr<EventInfo> info, EventID id)
-      : info(std::move(info)), write(std::move(write)), id(id) {}
+      : info(std::move(info)), write(std::move(write)), id(id), accessedMemory({}) {
+    this->info->thread.program.pta.getPointsTo(this->info->context, this->write->getAccessedValue(), accessedMemory);
+  }
 
   [[nodiscard]] inline EventID getID() const override { return id; }
   [[nodiscard]] inline const pta::ctx *getContext() const override { return info->context; }
   [[nodiscard]] inline const ThreadTrace &getThread() const override { return info->thread; }
   [[nodiscard]] inline const race::WriteIR *getIRInst() const override { return write.get(); }
 
-  [[nodiscard]] std::vector<const pta::ObjTy *> getAccessedMemory() const override;
+  [[nodiscard]] const std::multiset<const pta::ObjTy *> &getAccessedMemory() const override;
 };
 
 class ForkEventImpl : public ForkEvent {


### PR DESCRIPTION
Change optimises fetching accessed memory for memory access events by pre-caching accessed memory in a sorted container. Significantly improves speed of ThreadLocalAnalysis, may improve future analyses.