### PR TITLE
Reporting output optimisation

### DIFF
--- a/src/Reporter/Reporter.cpp
+++ b/src/Reporter/Reporter.cpp
@@ -85,15 +85,19 @@ llvm::raw_ostream &race::operator<<(llvm::raw_ostream &os, const RaceAccess &acc
 
 void race::to_json(json &j, const Race &race) { j = json{{"access1", race.first}, {"access2", race.second}}; }
 
-Report::Report(std::vector<std::pair<const WriteEvent *, const MemAccessEvent *>> racepairs) {
+Report::Report(const std::vector<std::pair<const WriteEvent *, const MemAccessEvent *>> &racepairs) {
+  size_t skipped = 0;
   for (auto const &racepair : racepairs) {
     Race race(racepair.first, racepair.second);
     if (race.missingLocation()) {
-      llvm::errs() << "skipping race with unknown location: " << race << "\n";
+      skipped++;
       continue;
     }
 
     races.insert(race);
+  }
+  if (skipped > 0) {
+    llvm::errs() << "skipped " << skipped << " races with unknown location\n";
   }
 }
 

--- a/src/Reporter/Reporter.h
+++ b/src/Reporter/Reporter.h
@@ -99,7 +99,7 @@ class Report {
  public:
   std::set<Race> races;
 
-  Report(std::vector<std::pair<const WriteEvent *, const MemAccessEvent *>> rawRaces);
+  Report(const std::vector<std::pair<const WriteEvent *, const MemAccessEvent *>> &rawRaces);
 
   inline bool empty() { return races.empty(); };
   inline std::size_t size() { return races.size(); };


### PR DESCRIPTION
Optimises output of reporting by warning about *count* of unknown location races. These are a majority of cases in medium targets, and outputting these errors are a majority of the flame graph.