### PR TITLE
Fix the broken debug info

### DIFF
--- a/src/Reporter/Reporter.h
+++ b/src/Reporter/Reporter.h
@@ -66,6 +66,7 @@ struct RaceAccess {
   bool operator==(const RaceAccess &other) const;
   bool operator!=(const RaceAccess &other) const;
   bool operator<(const RaceAccess &other) const;
+  void updateMisleadingDebugLoc();
 };
 
 void to_json(json &j, const RaceAccess &access);

--- a/tests/integration/dataracebench.test.cpp
+++ b/tests/integration/dataracebench.test.cpp
@@ -179,15 +179,15 @@ TEST_LL("DRB071", "DRB071-targetparallelfor-orig-no.ll", NORACE)
 // TEST_LL("DRB072", /*TODO*/, EXPECTED(/*TODO*/))
 
 // 73 broken debug info:
-// TEST_LL("DRB073", "DRB073-doall2-orig-yes.ll",
-//        EXPECTED("DRB073-doall2-orig-yes.c:61:0 DRB073-doall2-orig-yes.c:61:0",  // races on array index
-//                 "DRB073-doall2-orig-yes.c:61:0 DRB073-doall2-orig-yes.c:61:0",
-//                 "DRB073-doall2-orig-yes.c:61:0 DRB073-doall2-orig-yes.c:61:21",
-//                 "DRB073-doall2-orig-yes.c:61:0 DRB073-doall2-orig-yes.c:61:0",
-//                 "DRB073-doall2-orig-yes.c:61:0 DRB073-doall2-orig-yes.c:61:0",
-//                 "DRB073-doall2-orig-yes.c:61:0 DRB073-doall2-orig-yes.c:61:21",
-//                 "DRB073-doall2-orig-yes.c:62:14 DRB073-doall2-orig-yes.c:62:14",  // races on array elements
-//                 "DRB073-doall2-orig-yes.c:62:14 DRB073-doall2-orig-yes.c:62:15"))
+TEST_LL("DRB073", "DRB073-doall2-orig-yes.ll",
+        EXPECTED("DRB073-doall2-orig-yes.c:61:5 DRB073-doall2-orig-yes.c:61:5",  // races on array index
+                 "DRB073-doall2-orig-yes.c:61:5 DRB073-doall2-orig-yes.c:61:5",
+                 "DRB073-doall2-orig-yes.c:61:5 DRB073-doall2-orig-yes.c:61:21",
+                 "DRB073-doall2-orig-yes.c:61:5 DRB073-doall2-orig-yes.c:61:5",
+                 "DRB073-doall2-orig-yes.c:61:5 DRB073-doall2-orig-yes.c:61:5",
+                 "DRB073-doall2-orig-yes.c:61:5 DRB073-doall2-orig-yes.c:61:21",
+                 "DRB073-doall2-orig-yes.c:62:14 DRB073-doall2-orig-yes.c:62:14",  // races on array elements
+                 "DRB073-doall2-orig-yes.c:62:14 DRB073-doall2-orig-yes.c:62:15"))
 
 // 74 critical and flush
 // TEST_LL("DRB074", /*TODO*/, EXPECTED(/*TODO*/))


### PR DESCRIPTION
Fixed issue #230; passed DRB073.

This is not the best solution (since the column number is still wrong but quite close), but the simplest solution (do not need to overwrite llvm passes). 

(the original fix in the close sourced version: https://github.com/coderrect-inc/classic-flang-llvm-project/commit/f035640c1422e48b69c664628caece6f9917a2f1)