### PR TITLE
Indirect call

### DIFF
--- a/src/Analysis/LockSet.cpp
+++ b/src/Analysis/LockSet.cpp
@@ -13,6 +13,8 @@ limitations under the License.
 
 #include <set>
 
+extern llvm::cl::opt<bool> DEBUG;
+
 using namespace race;
 
 std::multiset<const llvm::Value *> LockSet::heldLocks(const Event *targetEvent) {
@@ -22,7 +24,7 @@ std::multiset<const llvm::Value *> LockSet::heldLocks(const Event *targetEvent) 
     return it->second;
   }
   std::multiset<const llvm::Value *> locks;
-  if (DEBUG_PTA) {
+  if (DEBUG) {
     llvm::outs() << "--------------------------\n";
   }
   auto const &thread = targetEvent->getThread();
@@ -34,7 +36,7 @@ std::multiset<const llvm::Value *> LockSet::heldLocks(const Event *targetEvent) 
       case Event::Type::Lock: {
         auto lockEvent = llvm::cast<LockEvent>(event.get());
         locks.insert(lockEvent->getIRInst()->getLockValue());
-        if (DEBUG_PTA) {
+        if (DEBUG) {
           llvm::outs() << "After lock: {";
           auto it = locks.begin();
           for (; it != locks.end(); it++) llvm::outs() << *it << " ";
@@ -49,7 +51,7 @@ std::multiset<const llvm::Value *> LockSet::heldLocks(const Event *targetEvent) 
         if (first != locks.end()) {  // only remove the first element
           locks.erase(first);
         }
-        if (DEBUG_PTA) {
+        if (DEBUG) {
           llvm::outs() << "After unlock: {";
           auto it = locks.begin();
           for (; it != locks.end(); it++) llvm::outs() << *it << " ";

--- a/src/Analysis/OpenMP/OpenMP.cpp
+++ b/src/Analysis/OpenMP/OpenMP.cpp
@@ -1,0 +1,105 @@
+/* Copyright 2021 Coderrect Inc. All Rights Reserved.
+Licensed under the GNU Affero General Public License, version 3 or later (“AGPL”), as published by the Free Software
+Foundation. You may not use this file except in compliance with the License. You may obtain a copy of the License at
+https://www.gnu.org/licenses/agpl-3.0.en.html
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an “AS IS” BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "OpenMP.h"
+
+#include "Trace/ProgramTrace.h"
+
+using namespace race;
+
+// Get any icmp_eq insts that use this value and compare against a constant integer
+// return list of pairs (cmp, c) where cmp is the cmpInst and c is the constant value compared against
+std::vector<std::pair<const llvm::CmpInst *, ThreadID>> race::getConstCmpEqInsts(const llvm::Value *value) {
+  std::vector<std::pair<const llvm::CmpInst *, ThreadID>> result;
+
+  std::vector<const llvm::User *> worklist;
+
+  for (auto user : value->users()) {
+    worklist.push_back(user);
+  }
+
+  while (!worklist.empty()) {
+    auto const user = worklist.back();
+    worklist.pop_back();
+
+    // follow loads
+    if (auto load = llvm::dyn_cast<llvm::LoadInst>(user)) {
+      std::copy(load->users().begin(), load->users().end(), std::back_inserter(worklist));
+      continue;
+    }
+
+    if (auto cmp = llvm::dyn_cast<llvm::CmpInst>(user)) {
+      if (cmp->getPredicate() != llvm::CmpInst::Predicate::ICMP_EQ) continue;
+
+      if (auto val = llvm::dyn_cast<llvm::ConstantInt>(cmp->getOperand(1))) {
+        result.emplace_back(cmp, val->getZExtValue());
+        continue;
+      }
+
+      if (auto val = llvm::dyn_cast<llvm::ConstantInt>(cmp->getOperand(0))) {
+        result.emplace_back(cmp, val->getZExtValue());
+        continue;
+      }
+    }
+  }
+
+  return result;
+}
+
+// Get list of blocks guarded by one case of this branch.
+// branch arg decides if checking for blocks guarded by true or false branch
+// Start by assuming the target block is guarded
+// Iterate from the target block until we find a block that has an unguarded predecessor
+// Cannot handle loops
+std::set<const llvm::BasicBlock *> race::getGuardedBlocks(const llvm::BranchInst *branchInst, bool branch) {
+  // This branch should use a cmp eq instruction
+  // Otherwise the true/false blocks below may be wrong
+  assert(llvm::isa<llvm::CmpInst>(branchInst->getOperand(0)));
+  assert(llvm::cast<llvm::CmpInst>(branchInst->getOperand(0))->getPredicate() == llvm::CmpInst::Predicate::ICMP_EQ);
+
+  auto trueBlock = llvm::cast<llvm::BasicBlock>(branchInst->getOperand(2));
+  auto falseBlock = llvm::cast<llvm::BasicBlock>(branchInst->getOperand(1));
+
+  auto const targetBlock = (branch) ? trueBlock : falseBlock;
+
+  // This will be the returned result
+  std::set<const llvm::BasicBlock *> guardedBlocks;
+  guardedBlocks.insert(targetBlock);
+
+  std::set<const llvm::BasicBlock *> visited;
+  std::vector<const llvm::BasicBlock *> worklist;
+
+  visited.insert(targetBlock);
+  std::copy(succ_begin(targetBlock), succ_end(targetBlock), std::back_inserter(worklist));
+
+  do {
+    auto const currentBlock = worklist.back();
+    worklist.pop_back();
+
+    auto hasUnguardedPred = std::any_of(
+        pred_begin(currentBlock), pred_end(currentBlock),
+        [&guardedBlocks](const llvm::BasicBlock *pred) { return guardedBlocks.find(pred) == guardedBlocks.end(); });
+
+    if (hasUnguardedPred) continue;
+    visited.insert(currentBlock);
+
+    guardedBlocks.insert(currentBlock);
+
+    for (auto next : successors(currentBlock)) {
+      if (visited.find(next) == visited.end()) {
+        worklist.push_back(next);
+      }
+    }
+
+  } while (!worklist.empty());
+
+  return guardedBlocks;
+}

--- a/src/Analysis/OpenMP/OpenMP.h
+++ b/src/Analysis/OpenMP/OpenMP.h
@@ -1,0 +1,25 @@
+/* Copyright 2021 Coderrect Inc. All Rights Reserved.
+Licensed under the GNU Affero General Public License, version 3 or later (“AGPL”), as published by the Free Software
+Foundation. You may not use this file except in compliance with the License. You may obtain a copy of the License at
+https://www.gnu.org/licenses/agpl-3.0.en.html
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an “AS IS” BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <set>
+#include <vector>
+
+#include "Trace/ThreadTrace.h"
+#include "llvm/IR/Instructions.h"
+
+namespace race {
+
+std::vector<std::pair<const llvm::CmpInst *, ThreadID>> getConstCmpEqInsts(const llvm::Value *value);
+std::set<const llvm::BasicBlock *> getGuardedBlocks(const llvm::BranchInst *branchInst, bool branch = true);
+
+}  // namespace race

--- a/src/Analysis/OpenMPAnalysis.cpp
+++ b/src/Analysis/OpenMPAnalysis.cpp
@@ -337,7 +337,7 @@ std::vector<Region> getRegions(const ThreadTrace &thread) {
   return regions;
 }
 
-// Get the innermost region that contains event
+// Get the only region that contains event
 template <Event::Type Start, Event::Type End>
 std::optional<Region> getContainingRegion(const Event *event) {
   if (!event) return std::nullopt;

--- a/src/Analysis/OpenMPAnalysis.cpp
+++ b/src/Analysis/OpenMPAnalysis.cpp
@@ -11,6 +11,7 @@ limitations under the License.
 
 #include "Analysis/OpenMPAnalysis.h"
 
+#include "Analysis/OpenMP/OpenMP.h"
 #include "LanguageModel/OpenMP.h"
 #include "Trace/Event.h"
 #include "Trace/ProgramTrace.h"
@@ -307,95 +308,6 @@ bool OpenMPAnalysis::inSameReduce(const Event *event1, const Event *event2) cons
 }
 
 namespace {
-
-// Get any icmp_eq insts that use this value and compare against a constant integer
-// return list of pairs (cmp, c) where cmp is the cmpInst and c is the constant value compared against
-std::vector<std::pair<const llvm::CmpInst *, ThreadID>> getConstCmpEqInsts(const llvm::Value *value) {
-  std::vector<std::pair<const llvm::CmpInst *, ThreadID>> result;
-
-  std::vector<const llvm::User *> worklist;
-
-  for (auto user : value->users()) {
-    worklist.push_back(user);
-  }
-
-  while (!worklist.empty()) {
-    auto const user = worklist.back();
-    worklist.pop_back();
-
-    // follow loads
-    if (auto load = llvm::dyn_cast<llvm::LoadInst>(user)) {
-      std::copy(load->users().begin(), load->users().end(), std::back_inserter(worklist));
-      continue;
-    }
-
-    if (auto cmp = llvm::dyn_cast<llvm::CmpInst>(user)) {
-      if (cmp->getPredicate() != llvm::CmpInst::Predicate::ICMP_EQ) continue;
-
-      if (auto val = llvm::dyn_cast<llvm::ConstantInt>(cmp->getOperand(1))) {
-        result.emplace_back(cmp, val->getZExtValue());
-        continue;
-      }
-
-      if (auto val = llvm::dyn_cast<llvm::ConstantInt>(cmp->getOperand(0))) {
-        result.emplace_back(cmp, val->getZExtValue());
-        continue;
-      }
-    }
-  }
-
-  return result;
-}
-
-// Get list of blocks guarded by one case of this branch.
-// branch arg decides if checking for blocks guarded by true or false branch
-// Start by assuming the target block is guarded
-// Iterate from the target block until we find a block that has an unguarded predecessor
-// Cannot handle loops
-std::set<const llvm::BasicBlock *> getGuardedBlocks(const llvm::BranchInst *branchInst, bool branch = true) {
-  // This branch should use a cmp eq instruction
-  // Otherwise the true/false blocks below may be wrong
-  assert(llvm::isa<llvm::CmpInst>(branchInst->getOperand(0)));
-  assert(llvm::cast<llvm::CmpInst>(branchInst->getOperand(0))->getPredicate() == llvm::CmpInst::Predicate::ICMP_EQ);
-
-  auto trueBlock = llvm::cast<llvm::BasicBlock>(branchInst->getOperand(2));
-  auto falseBlock = llvm::cast<llvm::BasicBlock>(branchInst->getOperand(1));
-
-  auto const targetBlock = (branch) ? trueBlock : falseBlock;
-
-  // This will be the returned result
-  std::set<const llvm::BasicBlock *> guardedBlocks;
-  guardedBlocks.insert(targetBlock);
-
-  std::set<const llvm::BasicBlock *> visited;
-  std::vector<const llvm::BasicBlock *> worklist;
-
-  visited.insert(targetBlock);
-  std::copy(succ_begin(targetBlock), succ_end(targetBlock), std::back_inserter(worklist));
-
-  do {
-    auto const currentBlock = worklist.back();
-    worklist.pop_back();
-
-    auto hasUnguardedPred = std::any_of(
-        pred_begin(currentBlock), pred_end(currentBlock),
-        [&guardedBlocks](const llvm::BasicBlock *pred) { return guardedBlocks.find(pred) == guardedBlocks.end(); });
-
-    if (hasUnguardedPred) continue;
-    visited.insert(currentBlock);
-
-    guardedBlocks.insert(currentBlock);
-
-    for (auto next : successors(currentBlock)) {
-      if (visited.find(next) == visited.end()) {
-        worklist.push_back(next);
-      }
-    }
-
-  } while (!worklist.empty());
-
-  return guardedBlocks;
-}
 
 // Get list of (non-nested) event regions
 // template definition can be in cpp as long as we dont expose the template outside of this file

--- a/src/Analysis/OpenMPAnalysis.h
+++ b/src/Analysis/OpenMPAnalysis.h
@@ -59,21 +59,27 @@ class SimpleGetThreadNumAnalysis {
   // simple implementation can only handle one block being guarded
   std::map<const llvm::BasicBlock*, u_int64_t> guardedBlocks;
 
+  // map of functions to the tid they are guarded, cached by getGuardedBy()
+  std::map<const llvm::Function*, int64_t> cached;
+
   // compute any guarded blocks for this omp_get_thread call and add them to the guardedBlocks map
   void computeGuardedBlocks(const Event* event);
 
   // set of get_thread_num calls who's guarded blocks have already been computed
   std::set<const llvm::Instruction*> visited;
 
+  // compute and cache the tid that guards this fn or none if not exist
+  std::optional<u_int64_t> computeGuardedFns(const Function* fn);
+
   // Get the tid that guards this event or None if it is not guarded
-  std::optional<u_int64_t> getGuardedBy(const Event* event) const;
+  std::optional<u_int64_t> getGuardedBy(const Event* event);
 
  public:
   explicit SimpleGetThreadNumAnalysis(const ProgramTrace& program);
 
   // Check if both events are guaranteed to be executed by a particular thread
   // via a branch on omp_get_thread_num checked against a constant value
-  bool guardedBySameTid(const Event* event1, const Event* event2) const;
+  bool guardedBySameTid(const Event* event1, const Event* event2);
 };
 
 class LastprivateAnalysis {
@@ -134,7 +140,7 @@ class OpenMPAnalysis {
 
   // return true if both events are gauranteed to execute on the same thread
   // by a check against omp_get_thread_num
-  bool guardedBySameTid(const Event* event1, const Event* event2) const {
+  bool guardedBySameTid(const Event* event1, const Event* event2) {
     return getThreadNumAnalysis.guardedBySameTid(event1, event2);
   }
 

--- a/src/Analysis/OpenMPAnalysis.h
+++ b/src/Analysis/OpenMPAnalysis.h
@@ -54,34 +54,6 @@ class ReduceAnalysis {
   bool reduceContains(const llvm::Instruction* reduce, const llvm::Instruction* inst) const;
 };
 
-class SimpleGetThreadNumAnalysis {
-  // map of blocks to the tid they are guarded by
-  // simple implementation can only handle one block being guarded
-  std::map<const llvm::BasicBlock*, u_int64_t> guardedBlocks;
-
-  // map of functions to the tid they are guarded, cached by getGuardedBy()
-  std::map<const llvm::Function*, int64_t> cached;
-
-  // compute any guarded blocks for this omp_get_thread call and add them to the guardedBlocks map
-  void computeGuardedBlocks(const Event* event);
-
-  // set of get_thread_num calls who's guarded blocks have already been computed
-  std::set<const llvm::Instruction*> visited;
-
-  // compute and cache the tid that guards this fn or none if not exist
-  std::optional<u_int64_t> computeGuardedFns(const Function* fn);
-
-  // Get the tid that guards this event or None if it is not guarded
-  std::optional<u_int64_t> getGuardedBy(const Event* event);
-
- public:
-  explicit SimpleGetThreadNumAnalysis(const ProgramTrace& program);
-
-  // Check if both events are guaranteed to be executed by a particular thread
-  // via a branch on omp_get_thread_num checked against a constant value
-  bool guardedBySameTid(const Event* event1, const Event* event2);
-};
-
 class LastprivateAnalysis {
   // We model last private by only checking if some access is in a last private block
   // We may miss some real races if different last private blocks can race with each other
@@ -105,7 +77,6 @@ class OpenMPAnalysis {
   llvm::FunctionAnalysisManager FAM;
 
   ReduceAnalysis reduceAnalysis;
-  SimpleGetThreadNumAnalysis getThreadNumAnalysis;
   LastprivateAnalysis lastprivate;
   SimpleArrayAnalysis arrayAnalysis;
 
@@ -131,18 +102,16 @@ class OpenMPAnalysis {
   // Call assumes the events are on different threads but in the same team
   bool inSameSingleBlock(const Event* event1, const Event* event2) const;
 
+  // return true if both events are gauranteed to execute on the same thread
+  // by a check against omp_get_thread_num
+  bool inSameGuardedTID(const Event* event1, const Event* event2) const;
+
   // return true if both events are inside of the same reduce region
   // we do not distinguise between reduce and reduce_nowait
   bool inSameReduce(const Event* event1, const Event* event2) const;
 
   // return true if both events are in compatible sections
   static bool insideCompatibleSections(const Event* event1, const Event* event2);
-
-  // return true if both events are gauranteed to execute on the same thread
-  // by a check against omp_get_thread_num
-  bool guardedBySameTid(const Event* event1, const Event* event2) {
-    return getThreadNumAnalysis.guardedBySameTid(event1, event2);
-  }
 
   bool isInLastprivate(const Event* event) const { return lastprivate.isGuarded(event->getInst()->getParent()); }
 

--- a/src/Analysis/SharedMemory.cpp
+++ b/src/Analysis/SharedMemory.cpp
@@ -10,6 +10,9 @@ limitations under the License.
 ==============================================================================*/
 
 #include "Analysis/SharedMemory.h"
+
+extern llvm::cl::opt<bool> DEBUG;
+
 using namespace race;
 
 SharedMemory::SharedMemory(const ProgramTrace &program) {
@@ -24,13 +27,13 @@ SharedMemory::SharedMemory(const ProgramTrace &program) {
     return id;
   };
 
-  if (DEBUG_PTA) {
+  if (DEBUG) {
     llvm::outs() << "** SharedMemory **"
                  << "\n";
   }
   for (auto const &thread : program.getThreads()) {
     auto const tid = thread->id;
-    if (DEBUG_PTA) {
+    if (DEBUG) {
       llvm::outs() << "------- tid: " << tid << "\n";
     }
 
@@ -39,7 +42,7 @@ SharedMemory::SharedMemory(const ProgramTrace &program) {
         case Event::Type::Read: {
           auto readEvent = llvm::cast<ReadEvent>(event.get());
           auto const ptsTo = readEvent->getAccessedMemory();
-          if (DEBUG_PTA) {
+          if (DEBUG) {
             if (ptsTo.empty()) {
               llvm::outs() << "Read: ID " << readEvent->getID();
               readEvent->getIRInst()->getInst()->print(llvm::outs());
@@ -56,11 +59,11 @@ SharedMemory::SharedMemory(const ProgramTrace &program) {
           for (auto obj : ptsTo) {
             auto &reads = objReads[getObjId(obj)][tid];
             reads.push_back(readEvent);
-            if (DEBUG_PTA) {
+            if (DEBUG) {
               llvm::outs() << obj->getValue() << " " << obj->getObjectID() << " " << getObjId(obj) << ", ";
             }
           }
-          if (DEBUG_PTA) {
+          if (DEBUG) {
             llvm::outs() << "\n";
           }
           break;
@@ -68,7 +71,7 @@ SharedMemory::SharedMemory(const ProgramTrace &program) {
         case Event::Type::Write: {
           auto writeEvent = llvm::cast<WriteEvent>(event.get());
           auto const ptsTo = writeEvent->getAccessedMemory();
-          if (DEBUG_PTA) {
+          if (DEBUG) {
             if (ptsTo.empty()) {
               llvm::outs() << "Write: ID " << writeEvent->getID();
               writeEvent->getIRInst()->getInst()->print(llvm::outs());
@@ -85,11 +88,11 @@ SharedMemory::SharedMemory(const ProgramTrace &program) {
           for (auto obj : ptsTo) {
             auto &writes = objWrites[getObjId(obj)][tid];
             writes.push_back(writeEvent);
-            if (DEBUG_PTA) {
+            if (DEBUG) {
               llvm::outs() << obj->getValue() << " " << obj->getObjectID() << " " << getObjId(obj) << ", ";
             }
           }
-          if (DEBUG_PTA) {
+          if (DEBUG) {
             llvm::outs() << "\n";
           }
           break;

--- a/src/Analysis/SimpleArrayAnalysis.cpp
+++ b/src/Analysis/SimpleArrayAnalysis.cpp
@@ -216,7 +216,7 @@ struct ArrayAccess {
     }
 
     llvm::StringRef rootIdx;
-    int i = 0;
+    unsigned int i = 0;
     while (i < geps.size()) {
       auto gep = geps[i];
       auto idx = gep->getOperand(gep->getNumOperands() - 1);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,8 +18,7 @@ set(pta-lib-sources
     PointerAnalysis/Models/MemoryModel/CppMemModel/PreprocessingPasses/RewriteModeledAPIPass.cpp
     PointerAnalysis/Models/MemoryModel/CppMemModel/SpecialObject/Vector.cpp
     PointerAnalysis/Models/MemoryModel/CppMemModel/SpecialObject/VTablePtr.cpp
-    PointerAnalysis/Models/LanguageModel/DefaultLangModel/DefaultLangModel.cpp
-        Analysis/OpenMP/OpenMP.h)
+    PointerAnalysis/Models/LanguageModel/DefaultLangModel/DefaultLangModel.cpp)
 
 add_library(pta STATIC ${pta-lib-sources})
 target_link_libraries(pta ${llvm_libs} pthread)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,7 +19,7 @@ set(pta-lib-sources
     PointerAnalysis/Models/MemoryModel/CppMemModel/SpecialObject/Vector.cpp
     PointerAnalysis/Models/MemoryModel/CppMemModel/SpecialObject/VTablePtr.cpp
     PointerAnalysis/Models/LanguageModel/DefaultLangModel/DefaultLangModel.cpp
-)
+        Analysis/OpenMP/OpenMP.h)
 
 add_library(pta STATIC ${pta-lib-sources})
 target_link_libraries(pta ${llvm_libs} pthread)
@@ -41,6 +41,7 @@ endif()
 
 set(racedetect-lib-sources
     LanguageModel/RaceModel.cpp
+    Analysis/OpenMP/OpenMP.cpp
     Analysis/HappensBeforeGraph.cpp
     Analysis/LockSet.cpp
     Analysis/SharedMemory.cpp

--- a/src/IR/Builder.cpp
+++ b/src/IR/Builder.cpp
@@ -72,9 +72,6 @@ std::shared_ptr<const FunctionSummary> generateFunctionSummary(const llvm::Funct
   FunctionSummary summary;
 
   for (auto const &basicblock : func.getBasicBlockList()) {
-    if (DEBUG_PTA) {
-      llvm::outs() << "bb: " << basicblock.getName() << "\n";
-    }
     for (auto it = basicblock.begin(), end = basicblock.end(); it != end; ++it) {
       auto inst = llvm::cast<llvm::Instruction>(it);
 

--- a/src/IR/Builder.cpp
+++ b/src/IR/Builder.cpp
@@ -22,7 +22,7 @@ limitations under the License.
 
 using namespace race;
 
-extern llvm::cl::opt<bool> DEBUG_PTA;
+extern llvm::cl::opt<bool> DEBUG;
 
 namespace {
 
@@ -75,7 +75,7 @@ std::shared_ptr<const FunctionSummary> generateFunctionSummary(const llvm::Funct
     for (auto it = basicblock.begin(), end = basicblock.end(); it != end; ++it) {
       auto inst = llvm::cast<llvm::Instruction>(it);
 
-      if (DEBUG_PTA) {
+      if (DEBUG) {
         inst->print(llvm::outs(), false);
         llvm::outs() << "\n";
       }

--- a/src/IR/IR.h
+++ b/src/IR/IR.h
@@ -71,7 +71,8 @@ class IR {
     OpenMPMasterEnd,
     OpenMPGetThreadNum,
     OpenMPTaskWait,
-    END_Call
+    END_Call,
+    None,
   } type;
   [[nodiscard]] virtual const llvm::Instruction *getInst() const = 0;
 

--- a/src/LanguageModel/RaceModel.cpp
+++ b/src/LanguageModel/RaceModel.cpp
@@ -15,6 +15,8 @@ limitations under the License.
 #include "LanguageModel/OpenMP.h"
 #include "LanguageModel/pthread.h"
 
+extern llvm::cl::opt<bool> DEBUG;
+
 using namespace pta;
 
 RaceModel::RaceModel(llvm::Module *M, llvm::StringRef entry) : Super(M, entry) {
@@ -118,7 +120,7 @@ bool RaceModel::isCompatible(const llvm::Instruction *callsite, const llvm::Func
   auto threadCreate = call->getCalledFunction();
   assert(threadCreate && "Indirect call should point to a function.");
 
-  if (DEBUG_PTA) {
+  if (DEBUG) {
     threadCreate->print(llvm::outs());
     llvm::outs() << "\n";
     target->print(llvm::outs());

--- a/src/PointerAnalysis/CMDOptions.cpp
+++ b/src/PointerAnalysis/CMDOptions.cpp
@@ -25,6 +25,7 @@ cl::opt<bool> CONFIG_VTABLE_MODE("Xenable-vtable", cl::desc("model vtable specia
 cl::opt<bool> CONFIG_USE_FI_MODE("Xuse-fi-model", cl::desc("use field insensitive analyse"), cl::init(false));
 
 // pta cmd options: set to default values
+cl::opt<bool> DEBUG("DEBUG", cl::desc("debug race detection"), cl::init(false));
 cl::opt<bool> DEBUG_PTA("DEBUG_PTA", cl::desc("debug pointer analysis"), cl::init(false));
 cl::opt<pta::IndirectResolveOption> INDIRECT_OPTION(
     "INDIRECT_OPTION", cl::desc("How to resolve indirect function calls"),

--- a/src/PointerAnalysis/Models/LanguageModel/ConsGraphBuilder.h
+++ b/src/PointerAnalysis/Models/LanguageModel/ConsGraphBuilder.h
@@ -192,6 +192,10 @@ class ConsGraphBuilder : public llvm::CtxInstVisitor<ctx, SubClass>, public PtrN
         if (auto objNode = llvm::cast<ObjNode>(node)) {
           auto object = objNode->getObject();
           if (object->isFunction()) {
+            if (DEBUG_PTA) {
+              llvm::outs() << "fnobj: " << object << "\n";
+            }
+
             // resolved to a function
             // JEFF: WHY A funPtrNode can have SO MANY indirect nodes?
             for (CallGraphNode<ctx> *indirectNode : funPtrNode->getIndirectNodes()) {
@@ -200,6 +204,11 @@ class ConsGraphBuilder : public llvm::CtxInstVisitor<ctx, SubClass>, public PtrN
               const llvm::Function *target = llvm::dyn_cast<llvm::Function>(object->getValue());
               auto callsite = indirectNode->getTargetFunPtr()->getCallSite();
               assert(target);
+
+              if (DEBUG_PTA) {
+                llvm::outs() << "Fn: " << *target << "\n"
+                             << " - callsite: " << callsite << "\n";
+              }
 
               if (indirectNode->getTargetFunPtr()->isInterceptedCallSite()) {
                 if (!static_cast<SubClass &>(*this).isCompatible(callsite, target)) {

--- a/src/RaceDetect.cpp
+++ b/src/RaceDetect.cpp
@@ -81,6 +81,9 @@ Report race::detectRaces(llvm::Module *module, DetectRaceConfig config) {
       return;
     }
 
+    // No race if guaranteed to be executed by same thread
+    if (ompAnalysis.inSameGuardedTID(write, other)) return;
+
     if (ompAnalysis.fromSameParallelRegion(write, other)) {
       // Non overlapping array accesses inside of an OpenMP loop are not races
       // e.g.
@@ -103,9 +106,6 @@ Report race::detectRaces(llvm::Module *module, DetectRaceConfig config) {
       //  but will not miss races according to how Clang generates OpenMP code (as of clang 10.0.1)
       if (ompAnalysis.isInLastprivate(write) && ompAnalysis.isInLastprivate(other)) return;
     }
-
-    // No race if guaranteed to be executed by same thread
-    if (ompAnalysis.inSameGuardedTID(write, other)) return;
 
     // Race detected
     reporter.collect(write, other);

--- a/src/RaceDetect.cpp
+++ b/src/RaceDetect.cpp
@@ -97,15 +97,15 @@ Report race::detectRaces(llvm::Module *module, DetectRaceConfig config) {
         return;
       }
 
-      // No race if guaranteed to be executed by same thread
-      if (ompAnalysis.guardedBySameTid(write, other)) return;
-
       // Lastprivate code will only be executed by one thread
       // Model lastprivate by assuming lastprivate code cannot race with other last private code
       // This may miss races according to OpenMP specification,
       //  but will not miss races according to how Clang generates OpenMP code (as of clang 10.0.1)
       if (ompAnalysis.isInLastprivate(write) && ompAnalysis.isInLastprivate(other)) return;
     }
+
+    // No race if guaranteed to be executed by same thread
+    if (ompAnalysis.inSameGuardedTID(write, other)) return;
 
     // Race detected
     reporter.collect(write, other);

--- a/src/RaceDetect.cpp
+++ b/src/RaceDetect.cpp
@@ -20,6 +20,8 @@ limitations under the License.
 #include "LanguageModel/RaceModel.h"
 #include "Trace/ProgramTrace.h"
 
+extern llvm::cl::opt<bool> DEBUG;
+
 using namespace race;
 
 Report race::detectRaces(llvm::Module *module, DetectRaceConfig config) {
@@ -58,7 +60,7 @@ Report race::detectRaces(llvm::Module *module, DetectRaceConfig config) {
 
   // Adds to report if race is detected between write and other
   auto checkRace = [&](const race::WriteEvent *write, const race::MemAccessEvent *other) {
-    if (DEBUG_PTA) {
+    if (DEBUG) {
       llvm::outs() << "Checking Race: " << write->getID() << "(TID " << write->getThread().id << ") "
                    << "(line" << write->getIRInst()->getInst()->getDebugLoc().getLine()  // DRB149 crash on this line
                    << " col" << write->getIRInst()->getInst()->getDebugLoc().getCol() << ")"
@@ -110,7 +112,7 @@ Report race::detectRaces(llvm::Module *module, DetectRaceConfig config) {
     // Race detected
     reporter.collect(write, other);
 
-    if (DEBUG_PTA) {
+    if (DEBUG) {
       llvm::outs() << " ... is race\n";
     }
   };
@@ -144,11 +146,11 @@ Report race::detectRaces(llvm::Module *module, DetectRaceConfig config) {
     }
   }
 
-  if (DEBUG_PTA) {
+  if (DEBUG) {
     happensbefore.debugDump(llvm::outs());
   }
 
-  if (DEBUG_PTA) {
+  if (DEBUG) {
     happensbefore.debugDump(llvm::outs());
   }
 

--- a/src/Trace/Event.cpp
+++ b/src/Trace/Event.cpp
@@ -14,7 +14,11 @@ limitations under the License.
 using namespace race;
 
 llvm::raw_ostream &race::operator<<(llvm::raw_ostream &os, const Event &event) {
-  os << event.getID() << " " << event.type << "\t" << *event.getInst();
+  os << event.getID() << " " << event.type << "\t";
+  if (event.getInst())
+    os << *event.getInst();
+  else
+    os << "no inst";
   return os;
 }
 
@@ -49,6 +53,12 @@ llvm::raw_ostream &race::operator<<(llvm::raw_ostream &os, const Event::Type &ty
       break;
     case Event::Type::ExternCall:
       os << "ExternCall";
+      break;
+    case Event::Type::GuardStart:
+      os << "GuardStart";
+      break;
+    case Event::Type::GuardEnd:
+      os << "GuardEnd";
       break;
     default:
       llvm_unreachable("Did you forget to update Event::Type operator<< ?");

--- a/src/Trace/EventImpl.h
+++ b/src/Trace/EventImpl.h
@@ -44,7 +44,7 @@ class ReadEventImpl : public ReadEvent {
   const EventID id;
 
   ReadEventImpl(std::shared_ptr<const ReadIR> read, std::shared_ptr<EventInfo> info, EventID id)
-      : info(std::move(info)), read(std::move(read)), id(id), accessedMemory({}) {
+      : info(std::move(info)), accessedMemory({}), read(std::move(read)), id(id) {
     this->info->thread.program.pta.getPointsTo(this->info->context, this->read->getAccessedValue(), accessedMemory);
   }
 
@@ -65,7 +65,7 @@ class WriteEventImpl : public WriteEvent {
   const EventID id;
 
   WriteEventImpl(std::shared_ptr<const WriteIR> write, std::shared_ptr<EventInfo> info, EventID id)
-      : info(std::move(info)), write(std::move(write)), id(id), accessedMemory({}) {
+      : info(std::move(info)), accessedMemory({}), write(std::move(write)), id(id) {
     this->info->thread.program.pta.getPointsTo(this->info->context, this->write->getAccessedValue(), accessedMemory);
   }
 
@@ -240,6 +240,48 @@ class ExternCallEventImpl : public ExternCallEvent {
   [[nodiscard]] const llvm::Function *getCalledFunction() const override {
     return call->getInst()->getCalledFunction();
   }
+};
+
+class EnterGuardEventImpl : public EnterGuardEvent {
+  std::shared_ptr<EventInfo> info;
+
+ public:
+  const size_t guardedTID;
+  const EventID id;
+
+  EnterGuardEventImpl(std::shared_ptr<EventInfo> info, ThreadID guardedTID, EventID id)
+      : info(std::move(info)), guardedTID(guardedTID), id(id) {}
+
+  [[nodiscard]] inline EventID getID() const override { return id; }
+  [[nodiscard]] inline const pta::ctx *getContext() const override { return info->context; }
+  [[nodiscard]] inline const ThreadTrace &getThread() const override { return info->thread; }
+  [[nodiscard]] inline const race::IR *getIRInst() const override { return nullptr; }
+  [[nodiscard]] const llvm::Instruction *getInst() const override { return nullptr; }
+  [[nodiscard]] const llvm::Function *getFunction() const { return nullptr; }
+  [[nodiscard]] race::IR::Type getIRType() const { return race::IR::Type::None; }
+
+  [[nodiscard]] inline size_t getGuardedTID() const override { return guardedTID; }
+};
+
+class ExitGuardEventImpl : public ExitGuardEvent {
+  std::shared_ptr<EventInfo> info;
+
+ public:
+  const size_t guardedTID;
+  const EventID id;
+
+  ExitGuardEventImpl(std::shared_ptr<EventInfo> info, ThreadID guardedTID, EventID id)
+      : info(std::move(info)), guardedTID(guardedTID), id(id) {}
+
+  [[nodiscard]] inline EventID getID() const override { return id; }
+  [[nodiscard]] inline const pta::ctx *getContext() const override { return info->context; }
+  [[nodiscard]] inline const ThreadTrace &getThread() const override { return info->thread; }
+  [[nodiscard]] inline const race::IR *getIRInst() const override { return nullptr; }
+  [[nodiscard]] const llvm::Instruction *getInst() const override { return nullptr; }
+  [[nodiscard]] const llvm::Function *getFunction() const { return nullptr; }
+  [[nodiscard]] race::IR::Type getIRType() const { return race::IR::Type::None; }
+
+  [[nodiscard]] inline size_t getGuardedTID() const override { return guardedTID; }
 };
 
 }  // namespace race

--- a/src/Trace/ProgramTrace.h
+++ b/src/Trace/ProgramTrace.h
@@ -70,6 +70,10 @@ struct OpenMPState {
   // set of omp_get_thread_num calls who's guarded blocks have already been computed
   std::set<const llvm::Instruction *> visited;
 
+  // set of omp_get_thread_num calls who's guarded blocks have already been computed
+  // and the call HAS a corresponding guarded block
+  std::set<const llvm::Instruction *> existGuards;
+
   // whether we call updateGuardedBlocks to check if reach any guarded block entry/exit
   // update to true when see a compare IR after the call to omp_get_thread_num
   bool checkGuardedBlock = false;

--- a/src/Trace/ThreadTrace.cpp
+++ b/src/Trace/ThreadTrace.cpp
@@ -211,8 +211,6 @@ void traverseCallNode(const pta::CallGraphNodeTy *node, const ThreadTrace &threa
 
   for (unsigned int i = 0; i < summary.size(); i++) {
     auto const &ir = summary.at(i);
-    ir->getInst()->print(llvm::outs(), true);
-    llvm::outs() << "\n";
 
     if (shouldSkipIR(ir, state)) {
       continue;

--- a/src/Trace/ThreadTrace.cpp
+++ b/src/Trace/ThreadTrace.cpp
@@ -205,7 +205,7 @@ bool handleOMPEvents(const CallIR *callIR, TraceBuildState &state, bool isMaster
     }
     case IR::Type::OpenMPGetThreadNum: {
       // this sequence of calls can be moved to state after refactoring
-      state.computeGuardedBlocks(callIR->getInst(), state);
+      computeGuardedBlocks(callIR->getInst(), state);
       state.openmp.checkGuardedBlock = true;
       return false;
     }

--- a/src/Trace/ThreadTrace.cpp
+++ b/src/Trace/ThreadTrace.cpp
@@ -123,7 +123,6 @@ bool handleOMPEvents(const CallIR *callIR, TraceBuildState &state, bool isMaster
       return false;
     }
     case IR::Type::OpenMPGetThreadNum: {
-      // this sequence of calls can be moved to state after refactoring
       bool foundBlock = computeGuardedBlocks(callIR->getInst(), state);
       state.openmp.checkGuardedBlock = state.openmp.checkGuardedBlock || foundBlock;
       return false;

--- a/src/Trace/ThreadTrace.cpp
+++ b/src/Trace/ThreadTrace.cpp
@@ -17,6 +17,8 @@ limitations under the License.
 #include "Trace/CallStack.h"
 #include "Trace/ProgramTrace.h"
 
+extern llvm::cl::opt<bool> DEBUG;
+
 using namespace race;
 
 namespace {
@@ -200,7 +202,7 @@ void traverseCallNode(const pta::CallGraphNodeTy *node, const ThreadTrace &threa
 
   callstack.push(func);
 
-  if (DEBUG_PTA) {
+  if (DEBUG) {
     llvm::outs() << "\nGenerating Func Sum: TID: " << thread.id << " Func: " << func->getName() << "\n";
   }
 

--- a/tests/data/integration/indirectcall/gmx_ana.h
+++ b/tests/data/integration/indirectcall/gmx_ana.h
@@ -1,0 +1,7 @@
+// https://github.com/gromacs/gromacs/blob/c3a8cd89ffad199cc1058b3c8db439efa1b626b4/src/gromacs/gmxana/gmx_ana.h
+
+int gmx_bar(int argc, char* argv[]);
+
+int gmx_bundle(int argc, char* argv[]);
+
+int gmx_chi(int argc, char* argv[]);

--- a/tests/data/integration/indirectcall/gmx_bar.cpp
+++ b/tests/data/integration/indirectcall/gmx_bar.cpp
@@ -1,0 +1,8 @@
+// https://github.com/gromacs/gromacs/blob/df463c2cf9e1ee786b2f6e224e5168933c378ecb/src/gromacs/gmxana/gmx_chi.cpp
+
+#include "gmx_ana.h"
+
+int gmx_bar(int argc, char* argv[]) {
+  std::cout << "This is running from gmx_bar." << argv;
+  return argc + 2;
+}

--- a/tests/data/integration/indirectcall/gmx_bundle.cpp
+++ b/tests/data/integration/indirectcall/gmx_bundle.cpp
@@ -1,0 +1,8 @@
+// https://github.com/gromacs/gromacs/blob/df463c2cf9e1ee786b2f6e224e5168933c378ecb/src/gromacs/gmxana/gmx_chi.cpp
+
+#include "gmx_ana.h"
+
+int gmx_bundle(int argc, char* argv[]) {
+  std::cout << "This is running from gmx_bundle." << argv;
+  return argc + 1;
+}

--- a/tests/data/integration/indirectcall/gmx_chi.cpp
+++ b/tests/data/integration/indirectcall/gmx_chi.cpp
@@ -1,0 +1,8 @@
+// https://github.com/gromacs/gromacs/blob/df463c2cf9e1ee786b2f6e224e5168933c378ecb/src/gromacs/gmxana/gmx_chi.cpp
+
+#include "gmx_ana.h"
+
+int gmx_chi(int argc, char* argv[]) {
+  std::cout << "This is running from gmx_chi." << argv;
+  return argc;
+}

--- a/tests/data/integration/indirectcall/indirect_call.cpp
+++ b/tests/data/integration/indirectcall/indirect_call.cpp
@@ -1,0 +1,114 @@
+// a mini example for gromacs:
+// mimic the use of map and indirect function pointers, the following links are references
+
+#include <iostream>
+#include <map>
+#include <memory>
+#include <string>
+
+// base class
+class ICommandLineModule {
+  // https://github.com/gromacs/gromacs/blob/6fff49f17a7a716451919691d689b0d621b981fe/src/gromacs/commandline/cmdlinemodule.h#L93
+ public:
+  virtual ~ICommandLineModule() {}
+
+  // Returns the name of the module.
+  virtual const char* name() const = 0;
+  // Runs the module with the given arguments
+  virtual int run(int argc, char* argv[]) = 0;
+};
+
+class Impl {
+  const char* name_;
+
+ public:
+  Impl(const char* name);
+
+  void doSomething(int num);
+};
+
+Impl::Impl(const char* name) : name_(name) {}
+
+void Impl::doSomething(int num) { std::cout << "This is running from CommandAImpl: " << num; }
+
+// inherent classes
+class CommandA : public ICommandLineModule {
+  // https://github.com/gromacs/gromacs/blob/e0039f23b58a0ea3c15a5b3775525ad5b06f4e30/src/gromacs/commandline/cmdlinehelpmodule.cpp#L883
+  // https://github.com/gromacs/gromacs/blob/e0039f23b58a0ea3c15a5b3775525ad5b06f4e30/src/gromacs/commandline/cmdlinehelpmodule.cpp#L848
+  const char* name_;
+
+ public:
+  CommandA(const char* name);
+  ~CommandA() override;
+
+  const char* name() const override { return name_; }
+  int run(int argc, char* argv[]) override;
+
+ private:
+  std::unique_ptr<Impl> impl_;
+};
+
+CommandA::CommandA(const char* name) : impl_(new Impl(name)) {}
+
+int CommandA::run(int argc, char* argv[]) {
+  impl_->doSomething(argc);
+  return 0;
+}
+
+class CommandB : public ICommandLineModule {
+  // https://github.com/gromacs/gromacs/blob/e0039f23b58a0ea3c15a5b3775525ad5b06f4e30/src/gromacs/commandline/cmdlineoptionsmodule.cpp#L107
+  const char* name_;
+
+ public:
+  explicit CommandB(const char* name) : name_(name) {}
+
+  const char* name() const override { return name_; }
+  int run(int argc, char* argv[]) override {
+    std::cout << "This is running from CommandB." << argv;
+    parseOption(argc, argv);
+    return 0;
+  }
+
+ private:
+  void parseOption(int argc, char* argv[]) { std::cout << "This is option: " << argv; }
+};
+
+class CommandC : public ICommandLineModule {
+  // https://github.com/gromacs/gromacs/blob/6fff49f17a7a716451919691d689b0d621b981fe/src/programs/legacymodules.cpp#L85
+  const char* name_;
+
+ public:
+  explicit CommandC(const char* name) : name_(name) {}
+
+  const char* name() const override { return name_; }
+  int run(int argc, char* argv[]) override {
+    printMsg(argc, argv);
+    return 0;
+  }
+
+ private:
+  void printMsg(int argc, char* argv[]) { std::cout << "This is running from CommandC." << argv; }
+};
+
+typedef std::unique_ptr<ICommandLineModule>
+    CommandLineModulePointer;  // https://github.com/gromacs/gromacs/blob/6fff49f17a7a716451919691d689b0d621b981fe/src/gromacs/commandline/cmdlinemodulemanager.h#L65
+typedef std::map<std::string, CommandLineModulePointer>
+    CommandLineModuleMap;  // https://github.com/gromacs/gromacs/blob/e0039f23b58a0ea3c15a5b3775525ad5b06f4e30/src/gromacs/commandline/cmdlinemodulemanager_impl.h#L64
+
+int main(int argc, char* argv[]) {
+  // https://github.com/gromacs/gromacs/blob/8dd21f717c82277c611b537d92c19348ded5b357/src/programs/gmx.cpp
+  CommandLineModuleMap modules;
+  auto module_a = std::make_unique<CommandA>("CommandA");
+  auto module_b = std::make_unique<CommandB>("CommandB");
+  auto module_c = std::make_unique<CommandC>("CommandC");
+
+  // https://github.com/gromacs/gromacs/blob/c18c5072ef8d5a50da253d37b6ad33dc550e9514/src/gromacs/commandline/cmdlinemodulemanager.cpp#L326
+  modules.insert(std::make_pair(std::string(module_a->name()), std::move(module_a)));
+  modules.insert(std::make_pair(std::string(module_b->name()), std::move(module_b)));
+  modules.insert(std::make_pair(std::string(module_c->name()), std::move(module_c)));
+
+  auto it = modules.find(argv[0]);
+  if (it == modules.end()) return -1;
+
+  it->second->run(argc, argv);
+}

--- a/tests/data/integration/indirectcall/indirect_call2.cpp
+++ b/tests/data/integration/indirectcall/indirect_call2.cpp
@@ -1,0 +1,88 @@
+// a mini example for gromacs:
+// mimic the use of map and indirect function pointers, the following links are references
+
+#include <iostream>
+#include <map>
+#include <memory>
+#include <string>
+
+#include "gmx_ana.h"
+
+// base class
+class ICommandLineModule {
+  // https://github.com/gromacs/gromacs/blob/6fff49f17a7a716451919691d689b0d621b981fe/src/gromacs/commandline/cmdlinemodule.h#L93
+ public:
+  virtual ~ICommandLineModule() {}
+
+  // Returns the name of the module.
+  virtual const char* name() const = 0;
+  // Runs the module with the given arguments
+  virtual int run(int argc, char* argv[]) = 0;
+};
+
+// Function pointer type for a C main function.
+// https://github.com/gromacs/gromacs/blob/6fff49f17a7a716451919691d689b0d621b981fe/src/gromacs/commandline/cmdlinemodulemanager.h#L98
+typedef int (*CMainFunction)(int argc, char* argv[]);
+
+// https://github.com/gromacs/gromacs/blob/6fff49f17a7a716451919691d689b0d621b981fe/src/gromacs/commandline/cmdlinemodulemanager.h#L65
+typedef std::unique_ptr<ICommandLineModule> CommandLineModulePointer;
+
+// inherent classes
+class CMainCommand : public ICommandLineModule {
+  // https://github.com/gromacs/gromacs/blob/c18c5072ef8d5a50da253d37b6ad33dc550e9514/src/gromacs/commandline/cmdlinemodulemanager.cpp#L89
+ public:
+  typedef CMainFunction CMainFunction;
+
+  /*!
+   * Creates a wrapper module for the given main function.
+   * \param[in] name             Name for the module.
+   * \param[in] mainFunction     Main function to wrap.
+   */
+  CMainCommand(const char* name, CMainFunction mainFunction) : name_(name), mainFunction_(mainFunction) {}
+
+  const char* name() const override { return name_; }
+  int run(int argc, char* argv[]) override { return mainFunction_(argc, argv); }
+
+ private:
+  const char* name_;
+  CMainFunction mainFunction_;
+};
+
+typedef std::unique_ptr<ICommandLineModule>
+    CommandLineModulePointer;  // https://github.com/gromacs/gromacs/blob/6fff49f17a7a716451919691d689b0d621b981fe/src/gromacs/commandline/cmdlinemodulemanager.h#L65
+typedef std::map<std::string, CommandLineModulePointer>
+    CommandLineModuleMap;  // https://github.com/gromacs/gromacs/blob/e0039f23b58a0ea3c15a5b3775525ad5b06f4e30/src/gromacs/commandline/cmdlinemodulemanager_impl.h#L64
+
+class CommandLineModuleManager {
+  // https://github.com/gromacs/gromacs/blob/6fff49f17a7a716451919691d689b0d621b981fe/src/gromacs/commandline/cmdlinemodulemanager.h#L94
+
+  CommandLineModuleMap modules;
+
+ public:
+  CommandLineModuleManager();
+
+  void addModuleMain(const char* name, CMainFunction mainFunction) {
+    // https://github.com/gromacs/gromacs/blob/c18c5072ef8d5a50da253d37b6ad33dc550e9514/src/gromacs/commandline/cmdlinemodulemanager.cpp#L468
+    CommandLineModulePointer module(new CMainCommand(name, mainFunction));
+    modules.insert(std::make_pair(std::string(name), std::move(module)));
+  }
+
+  void runAsMain(int argc, char* argv[]) {
+    // https://github.com/gromacs/gromacs/blob/c18c5072ef8d5a50da253d37b6ad33dc550e9514/src/gromacs/commandline/cmdlinemodulemanager.cpp#L600
+    auto it = modules.find(argv[0]);
+    if (it == modules.end()) return;
+
+    it->second->run(argc, argv);
+  }
+};
+
+int main(int argc, char* argv[]) {
+  // https://github.com/gromacs/gromacs/blob/8dd21f717c82277c611b537d92c19348ded5b357/src/programs/gmx.cpp
+  CommandLineModuleManager manager;
+
+  manager.addModuleMain("chi", &gmx_chi);
+  manager.addModuleMain("bar", &gmx_bar);
+  manager.addModuleMain("bundle", &gmx_bundle);
+
+  manager.runAsMain(argc, argv);
+}

--- a/tests/data/integration/indirectcall/simple.cpp
+++ b/tests/data/integration/indirectcall/simple.cpp
@@ -1,0 +1,67 @@
+#include <cassert>
+#include <iostream>
+#include <map>
+#include <string>
+#include <typeindex>
+#include <typeinfo>
+#include <vector>
+
+void fun1(void) { std::cout << "inside fun1\n"; }
+
+int fun2() {
+  std::cout << "inside fun2\n";
+  return 2;
+}
+
+int fun3(int a) {
+  std::cout << "inside fun3\n";
+  return a;
+}
+
+std::vector<int> fun4() {
+  std::cout << "inside fun4\n";
+  std::vector<int> v(4, 100);
+  return v;
+}
+
+// every function pointer will be stored as this type
+typedef void (*voidFunctionType)(void);
+
+struct Interface {
+  std::map<std::string, std::pair<voidFunctionType, std::type_index>> m1;
+
+  template <typename T>
+  void insert(std::string s1, T f1) {
+    auto tt = std::type_index(typeid(f1));
+    m1.insert(std::make_pair(s1, std::make_pair((voidFunctionType)f1, tt)));
+  }
+
+  template <typename T, typename... Args>
+  T searchAndCall(std::string s1, Args&&... args) {
+    auto mapIter = m1.find(s1);
+    /*chk if not end*/
+    auto mapVal = mapIter->second;
+
+    // auto typeCastedFun = reinterpret_cast<T(*)(Args ...)>(mapVal.first);
+    auto typeCastedFun = (T(*)(Args...))(mapVal.first);
+
+    // compare the types is equal or not
+    assert(mapVal.second == std::type_index(typeid(typeCastedFun)));
+    return typeCastedFun(std::forward<Args>(args)...);
+  }
+};
+
+int main() {
+  Interface a1;
+  a1.insert("fun1", fun1);
+  a1.insert("fun2", fun2);
+  a1.insert("fun3", fun3);
+  a1.insert("fun4", fun4);
+
+  a1.searchAndCall<void>("fun1");
+  int retVal = a1.searchAndCall<int>("fun3", 2);
+  a1.searchAndCall<int>("fun2");
+  auto temp = a1.searchAndCall<std::vector<int>>("fun4");
+
+  return 0;
+}

--- a/tests/data/integration/openmp/get-thread-num-interproc-no.c
+++ b/tests/data/integration/openmp/get-thread-num-interproc-no.c
@@ -1,7 +1,8 @@
 #include <omp.h>
 #include <stdio.h>
 
-void write_val(int *dest, int val) { *dest = val; }
+void write_val2(int *dest, int val) { *dest = val; }
+void write_val(int *dest, int val) { write_val2(dest, val); }
 
 int main() {
   int counter = 0;

--- a/tests/data/integration/openmp/get-thread-num-interproc-no2.c
+++ b/tests/data/integration/openmp/get-thread-num-interproc-no2.c
@@ -1,0 +1,22 @@
+#include <omp.h>
+#include <stdio.h>
+
+void write_val2(int *dest, int val) { *dest = val; }
+void write_val(int *dest, int val) { write_val2(dest, val); }
+
+int main() {
+  int counter = 0;
+
+#pragma omp parallel
+  {
+    int tid = omp_get_thread_num();
+
+    if (tid == 1) {
+      write_val(&counter, tid);
+      int tid2 = omp_get_thread_num();
+      printf("%d\n", tid2);
+    }
+  }
+
+  printf("%d\n", counter);
+}

--- a/tests/data/integration/openmp/get-thread-num-interproc-yes.c
+++ b/tests/data/integration/openmp/get-thread-num-interproc-yes.c
@@ -1,0 +1,20 @@
+#include <omp.h>
+#include <stdio.h>
+
+void write_val(int *dest, int val) { *dest = val; }
+
+int main() {
+  int counter = 0;
+
+#pragma omp parallel
+  {
+    int tid = omp_get_thread_num();
+
+    if (tid == 1) {
+      write_val(&counter, tid);
+    }
+    write_val(&counter, tid);
+  }
+
+  printf("%d\n", counter);
+}

--- a/tests/integration/openmp.test.cpp
+++ b/tests/integration/openmp.test.cpp
@@ -73,6 +73,7 @@ TEST_LL("get-thread-num-yes", "get-thread-num-yes.ll",
         EXPECTED("get-thread-num-yes.c:12:14 get-thread-num-yes.c:12:14",
                  "get-thread-num-yes.c:12:14 get-thread-num-yes.c:12:14"))
 TEST_LL("get-thread-num-interproc-no", "get-thread-num-interproc-no.ll", NORACE)
+TEST_LL("get-thread-num-interproc-no2", "get-thread-num-interproc-no2.ll", NORACE)
 TEST_LL("get-thread-num-interproc-yes", "get-thread-num-interproc-yes.ll",
         EXPECTED("get-thread-num-interproc-yes.c:4:44 get-thread-num-interproc-yes.c:4:44"))
 TEST_LL("get-thread-num-loop-no", "get-thread-num-loop-no.ll", NORACE)

--- a/tests/integration/openmp.test.cpp
+++ b/tests/integration/openmp.test.cpp
@@ -73,6 +73,8 @@ TEST_LL("get-thread-num-yes", "get-thread-num-yes.ll",
         EXPECTED("get-thread-num-yes.c:12:14 get-thread-num-yes.c:12:14",
                  "get-thread-num-yes.c:12:14 get-thread-num-yes.c:12:14"))
 TEST_LL("get-thread-num-interproc-no", "get-thread-num-interproc-no.ll", NORACE)
+TEST_LL("get-thread-num-interproc-yes", "get-thread-num-interproc-yes.ll",
+        EXPECTED("get-thread-num-interproc-yes.c:4:44 get-thread-num-interproc-yes.c:4:44"))
 TEST_LL("get-thread-num-loop-no", "get-thread-num-loop-no.ll", NORACE)
 TEST_LL("get-thread-num-nested-branch-no", "get-thread-num-nested-branch-no.ll", NORACE)
 TEST_LL("get-thread-num-double-no", "get-thread-num-double-no.ll", NORACE)

--- a/tests/integration/openmp.test.cpp
+++ b/tests/integration/openmp.test.cpp
@@ -72,7 +72,7 @@ TEST_LL("get-thread-num-no", "get-thread-num-no.ll", NORACE)
 TEST_LL("get-thread-num-yes", "get-thread-num-yes.ll",
         EXPECTED("get-thread-num-yes.c:12:14 get-thread-num-yes.c:12:14",
                  "get-thread-num-yes.c:12:14 get-thread-num-yes.c:12:14"))
-// TEST_LL("get-thread-num-interproc-no", "get-thread-num-interproc-no.ll", NORACE) cannot handle interproc yet
+TEST_LL("get-thread-num-interproc-no", "get-thread-num-interproc-no.ll", NORACE)
 TEST_LL("get-thread-num-loop-no", "get-thread-num-loop-no.ll", NORACE)
 TEST_LL("get-thread-num-nested-branch-no", "get-thread-num-nested-branch-no.ll", NORACE)
 TEST_LL("get-thread-num-double-no", "get-thread-num-double-no.ll", NORACE)


### PR DESCRIPTION
This branch contains two examples which mimic the use of map and indirect function pointers in gromacs (in `tests/data/integration/indirectcall/`). 

Working on reducing false points-to constraints/call edges from indirect calls.