### PR TITLE
make all OpenMP IR names consistent

### DIFF
--- a/src/IR/Builder.cpp
+++ b/src/IR/Builder.cpp
@@ -125,15 +125,15 @@ std::shared_ptr<const FunctionSummary> generateFunctionSummary(const llvm::Funct
         } else if (PthreadModel::isPthreadSpinUnlock(funcName)) {
           summary.push_back(std::make_shared<PthreadSpinUnlock>(callInst));
         } else if (OpenMPModel::isForStaticInit(funcName)) {
-          summary.push_back(std::make_shared<OmpForInit>(callInst));
+          summary.push_back(std::make_shared<OpenMPForInit>(callInst));
         } else if (OpenMPModel::isForStaticFini(funcName)) {
-          summary.push_back(std::make_shared<OmpForFini>(callInst));
+          summary.push_back(std::make_shared<OpenMPForFini>(callInst));
         } else if (OpenMPModel::isForDispatchInit(funcName)) {
-          summary.push_back(std::make_shared<OmpDispatchInit>(callInst));
+          summary.push_back(std::make_shared<OpenMPDispatchInit>(callInst));
         } else if (OpenMPModel::isForDispatchNext(funcName)) {
-          summary.push_back(std::make_shared<OmpDispatchNext>(callInst));
+          summary.push_back(std::make_shared<OpenMPDispatchNext>(callInst));
         } else if (OpenMPModel::isForDispatchFini(funcName)) {
-          summary.push_back(std::make_shared<OmpDispatchFini>(callInst));
+          summary.push_back(std::make_shared<OpenMPDispatchFini>(callInst));
         } else if (OpenMPModel::isSingleStart(funcName)) {
           summary.push_back(std::make_shared<OpenMPSingleStart>(callInst));
         } else if (OpenMPModel::isSingleEnd(funcName)) {

--- a/src/IR/IRImpls.h
+++ b/src/IR/IRImpls.h
@@ -400,7 +400,7 @@ class OpenMPBarrier : public BarrierIR {
 // =================================================================
 
 // CallIRImpl should not be used directly. Instead define using alias.
-// See OmpForInit below as an example.
+// See OpenMPForInit below as an example.
 template <const IR::Type T>
 class CallIRImpl : public CallIR {
  public:
@@ -410,12 +410,12 @@ class CallIRImpl : public CallIR {
   static inline bool classof(const IR *e) { return e->type == T; }
 };
 
-using OmpForInit = CallIRImpl<IR::Type::OpenMPForInit>;
-using OmpForFini = CallIRImpl<IR::Type::OpenMPForFini>;
+using OpenMPForInit = CallIRImpl<IR::Type::OpenMPForInit>;
+using OpenMPForFini = CallIRImpl<IR::Type::OpenMPForFini>;
 
-using OmpDispatchInit = CallIRImpl<IR::Type::OpenMPDispatchInit>;
-using OmpDispatchNext = CallIRImpl<IR::Type::OpenMPDispatchNext>;
-using OmpDispatchFini = CallIRImpl<IR::Type::OpenMPDispatchFini>;
+using OpenMPDispatchInit = CallIRImpl<IR::Type::OpenMPDispatchInit>;
+using OpenMPDispatchNext = CallIRImpl<IR::Type::OpenMPDispatchNext>;
+using OpenMPDispatchFini = CallIRImpl<IR::Type::OpenMPDispatchFini>;
 
 using OpenMPSingleStart = CallIRImpl<IR::Type::OpenMPSingleStart>;
 using OpenMPSingleEnd = CallIRImpl<IR::Type::OpenMPSingleEnd>;


### PR DESCRIPTION
Change the IR class names to match their IR type names.

This is a small change I split out from the larger refactoring/cleanup changes I am working on.