### PR TITLE
Add code to measure coverage of openrace

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,7 +55,8 @@ set(racedetect-lib-sources
     Trace/ProgramTrace.cpp
     Trace/ThreadTrace.cpp
     Reporter/Reporter.cpp
-    RaceDetect.cpp )
+    Statistics/Coverage.cpp
+    RaceDetect.cpp)
 add_library(racedetect-lib STATIC ${racedetect-lib-sources})
 target_link_libraries(racedetect-lib pta CONAN_PKG::nlohmann_json)
 target_include_directories(racedetect-lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/RaceDetect.cpp
+++ b/src/RaceDetect.cpp
@@ -18,6 +18,7 @@ limitations under the License.
 #include "Analysis/SimpleAlias.h"
 #include "Analysis/ThreadLocalAnalysis.h"
 #include "LanguageModel/RaceModel.h"
+#include "Statistics/Coverage.h"
 #include "Trace/ProgramTrace.h"
 
 using namespace race;
@@ -150,6 +151,14 @@ Report race::detectRaces(llvm::Module *module, DetectRaceConfig config) {
 
   if (DEBUG_PTA) {
     happensbefore.debugDump(llvm::outs());
+  }
+
+  if (config.doCoverage) {
+    race::Coverage coverage(program);
+    coverage.computeFnCoverage();
+    coverage.computeMemAccessCoverage();
+
+    llvm::outs() << coverage << "\n";
   }
 
   return reporter.getReport();

--- a/src/RaceDetect.cpp
+++ b/src/RaceDetect.cpp
@@ -155,9 +155,6 @@ Report race::detectRaces(llvm::Module *module, DetectRaceConfig config) {
 
   if (config.doCoverage) {
     race::Coverage coverage(program);
-    coverage.computeFnCoverage();
-    coverage.computeMemAccessCoverage();
-
     llvm::outs() << coverage << "\n";
   }
 

--- a/src/RaceDetect.h
+++ b/src/RaceDetect.h
@@ -21,6 +21,9 @@ struct DetectRaceConfig {
 
   // Print the ProgramTrace when true
   bool printTrace = false;
+
+  // Compute and print the coverage (= analyzed source code/all source code)
+  bool doCoverage = false;
 };
 
 Report detectRaces(llvm::Module *module, DetectRaceConfig config = DetectRaceConfig());

--- a/src/Statistics/Coverage.cpp
+++ b/src/Statistics/Coverage.cpp
@@ -21,7 +21,7 @@ namespace {
 
 // a function signature = return val type (param type(s)) function name
 // cannot find a better way to compute signature of fn without transferring between std::string and llvm::StringRef
-llvm::StringRef getSignature(const Function *fn) {
+std::string getSignature(const Function *fn) {
   llvm::FunctionType *typ = fn->getFunctionType();
   std::string s;
   llvm::raw_string_ostream os(s);
@@ -29,14 +29,11 @@ llvm::StringRef getSignature(const Function *fn) {
   os << " " << fn->getName();
   os.str();
 
-  llvm::outs() << "-" << llvm::StringRef(s) << "\n";
-
-  return llvm::StringRef(s);
+  return s;
 }
 
-void recordFn(std::map<llvm::StringRef, const llvm::Function *> &map, const llvm::Function *fn) {
-  llvm::StringRef sig = getSignature(fn);
-  llvm::outs() << "+" << sig << "\n";
+void recordFn(std::map<std::string, const llvm::Function *> &map, const llvm::Function *fn) {
+  std::string sig = getSignature(fn);
   auto exist = map.find(sig);
   if (exist == map.end()) {
     map.insert(std::make_pair(sig, fn));
@@ -133,9 +130,10 @@ llvm::raw_ostream &race::operator<<(llvm::raw_ostream &os, const Coverage &cvg) 
   auto data = cvg.data;
   os << "==== Coverage ====\n-> OpenRace Analyzed "
      << (static_cast<float>(data.analyzed.size()) / static_cast<float>(data.total.size())) * 100 << "% functions."
-     << "\n#Fn (from .ll/.bc file): " << data.total.size() << "\n#Fn (openrace visited): " << data.analyzed.size()
-     << "\nUnvisited Functions:\n";
+     << "\n#Fn (from .ll/.bc file): " << data.total.size() << "\n#Fn (openrace visited): " << data.analyzed.size();
+
   if (!data.unAnalyzed.empty()) {
+    os << "\nUnvisited Functions:\n";
     for (auto unVisit : data.unAnalyzed) {
       os << "\t" << unVisit << "\n";
     }
@@ -143,7 +141,7 @@ llvm::raw_ostream &race::operator<<(llvm::raw_ostream &os, const Coverage &cvg) 
 
   os << "\nVisited Functions:\n";
   for (auto visit : data.analyzed) {
-    os << "\t" << visit.first.str() << "\n";
+    os << "\t" << visit.first << "\n";
   }
 
   return os;

--- a/src/Statistics/Coverage.cpp
+++ b/src/Statistics/Coverage.cpp
@@ -1,0 +1,150 @@
+/* Copyright 2021 Coderrect Inc. All Rights Reserved.
+Licensed under the GNU Affero General Public License, version 3 or later (“AGPL”), as published by the Free Software
+Foundation. You may not use this file except in compliance with the License. You may obtain a copy of the License at
+https://www.gnu.org/licenses/agpl-3.0.en.html
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an “AS IS” BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "Coverage.h"
+
+#include <llvm/ADT/StringRef.h>
+
+#include "Trace/ProgramTrace.h"
+
+using namespace race;
+
+namespace {
+
+// a function signature = return val type (param type(s)) function name
+// cannot find a better way to compute signature of fn without transferring between std::string and llvm::StringRef
+llvm::StringRef getSignature(const Function *fn) {
+  llvm::FunctionType *typ = fn->getFunctionType();
+  std::string s;
+  llvm::raw_string_ostream os(s);
+  typ->print(os);
+  os << " " << fn->getName();
+  os.str();
+
+  llvm::outs() << "-" << llvm::StringRef(s) << "\n";
+
+  return llvm::StringRef(s);
+}
+
+void recordFn(std::map<llvm::StringRef, const llvm::Function *> &map, const llvm::Function *fn) {
+  llvm::StringRef sig = getSignature(fn);
+  llvm::outs() << "+" << sig << "\n";
+  auto exist = map.find(sig);
+  if (exist == map.end()) {
+    map.insert(std::make_pair(sig, fn));
+    llvm::outs() << "+" << fn->getName() << "\n";
+  }
+}
+
+}  // namespace
+
+Coverage::Coverage(const ProgramTrace &program) : program(program), module(program.getModule()) { summarize(); }
+
+void Coverage::summarize() {
+  if (!data.analyzed.empty() || !data.total.empty()) return;  // already computed
+
+  // collect fns in module
+  llvm::outs() << "From module: \n";
+  for (auto const &func : module.getFunctionList()) {
+    auto name = func.getName();
+    if (name.startswith("llvm.")) continue;  // e.g., llvm.dbg.declare, llvm.lifetime.start.p0i8
+    auto fn = module.getFunction(name);
+    recordFn(data.total, fn);
+  }
+
+  // collect fns in program
+  llvm::outs() << "\nFrom program : \n";
+  for (auto const &thread : program.getThreads()) {
+    for (auto const &event : thread->getEvents()) {
+      auto eventFn = event->getFunction();
+      recordFn(data.analyzed, eventFn);
+
+      switch (event->type) {
+        case Event::Type::Lock: {
+          auto lock = llvm::cast<LockEvent>(event.get());
+          auto fn = lock->getFunction();
+          if (fn) {
+            recordFn(data.analyzed, fn);
+          }
+          break;
+        }
+        case Event::Type::Unlock: {
+          auto unlock = llvm::cast<UnlockEvent>(event.get());
+          auto fn = unlock->getFunction();
+          if (fn) {
+            recordFn(data.analyzed, fn);
+          }
+          break;
+        }
+        case Event::Type::Call: {
+          auto call = llvm::cast<EnterCallEvent>(event.get());
+          auto fn = call->getCalledFunction();
+          recordFn(data.analyzed, fn);
+          break;
+        }
+        case Event::Type::ExternCall: {
+          auto exCall = llvm::cast<ExternCallEvent>(event.get());
+          auto exFn = exCall->getCalledFunction();
+          recordFn(data.analyzed, exFn);
+          break;
+        }
+        case Event::Type::Fork: {
+          auto fork = llvm::cast<ForkEvent>(event.get());
+          auto forkCall = llvm::cast<llvm::CallBase>(fork->getInst());
+          recordFn(data.analyzed, forkCall->getCalledFunction());
+          break;
+        }
+        case Event::Type::Join: {
+          auto join = llvm::cast<JoinEvent>(event.get());
+          auto joinCall = llvm::cast<llvm::CallBase>(join->getInst());
+          if (joinCall) {
+            recordFn(data.analyzed, joinCall->getCalledFunction());
+          }
+          break;
+        }
+        default:
+          break;
+      }
+    }
+  }
+}
+
+void Coverage::computeFnCoverage() {
+  for (auto it = data.total.begin(); it != data.total.end(); it++) {
+    auto sig = it->first;
+    auto found = data.analyzed.find(sig);
+    if (found == data.analyzed.end()) {  // not analyzed by openrace
+      data.unAnalyzed.insert(data.unAnalyzed.begin(), sig);
+    }
+  }
+}
+
+void Coverage::computeMemAccessCoverage() {}
+
+llvm::raw_ostream &race::operator<<(llvm::raw_ostream &os, const Coverage &cvg) {
+  auto data = cvg.data;
+  os << "==== Coverage ====\n-> OpenRace Analyzed "
+     << (static_cast<float>(data.analyzed.size()) / static_cast<float>(data.total.size())) * 100 << "% functions."
+     << "\n#Fn (from .ll/.bc file): " << data.total.size() << "\n#Fn (openrace visited): " << data.analyzed.size()
+     << "\nUnvisited Functions:\n";
+  if (!data.unAnalyzed.empty()) {
+    for (auto unVisit : data.unAnalyzed) {
+      os << "\t" << unVisit << "\n";
+    }
+  }
+
+  os << "\nVisited Functions:\n";
+  for (auto visit : data.analyzed) {
+    os << "\t" << visit.first.str() << "\n";
+  }
+
+  return os;
+}

--- a/src/Statistics/Coverage.h
+++ b/src/Statistics/Coverage.h
@@ -11,7 +11,6 @@ limitations under the License.
 
 #pragma once
 
-#include <llvm/ADT/StringRef.h>
 #include <llvm/IR/Module.h>
 
 #include "Trace/ProgramTrace.h"
@@ -25,8 +24,12 @@ struct CoverageData {
   // a map of fn signature with fn from program
   std::map<std::string, const llvm::Function *> analyzed;
 
-  // a set of fn that openrace does not analyze
-  std::vector<std::string> unAnalyzed;
+  // a map of fn that openrace does not analyze, and whether it is external
+  std::map<std::string, bool> unAnalyzed;
+
+  // TODO: are external and unAnalyzedExternal always the same? should be
+  unsigned int external = 0;            // the size of external functions from .bc/.ll
+  unsigned int unAnalyzedExternal = 0;  // the size of unanalyzed external functions
 };
 
 class Coverage {

--- a/src/Statistics/Coverage.h
+++ b/src/Statistics/Coverage.h
@@ -1,0 +1,54 @@
+/* Copyright 2021 Coderrect Inc. All Rights Reserved.
+Licensed under the GNU Affero General Public License, version 3 or later (“AGPL”), as published by the Free Software
+Foundation. You may not use this file except in compliance with the License. You may obtain a copy of the License at
+https://www.gnu.org/licenses/agpl-3.0.en.html
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an “AS IS” BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <llvm/ADT/StringRef.h>
+#include <llvm/IR/Module.h>
+
+#include "Trace/ProgramTrace.h"
+
+namespace race {
+
+struct CoverageData {
+  // a map of fn signature with fn from module
+  std::map<llvm::StringRef, const llvm::Function *> total;
+
+  // a map of fn signature with fn from program
+  std::map<llvm::StringRef, const llvm::Function *> analyzed;
+
+  // a set of fn that openrace does not analyze
+  std::vector<llvm::StringRef> unAnalyzed;
+};
+
+class Coverage {
+  const ProgramTrace &program;
+  const llvm::Module &module;
+
+ public:
+  explicit Coverage(const ProgramTrace &program);
+
+  CoverageData data;
+
+  // compute coverage = (#function analyzed in openrace/#function in the whole program IR)
+  void computeFnCoverage();
+
+  // compute coverage = (#read and write analyzed in openrace/#read and write in the whole program IR)
+  void computeMemAccessCoverage();
+
+ private:
+  // compute necessary information in CoverageData
+  void summarize();
+};
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Coverage &cvg);
+
+}  // namespace race

--- a/src/Statistics/Coverage.h
+++ b/src/Statistics/Coverage.h
@@ -20,13 +20,13 @@ namespace race {
 
 struct CoverageData {
   // a map of fn signature with fn from module
-  std::map<llvm::StringRef, const llvm::Function *> total;
+  std::map<std::string, const llvm::Function *> total;
 
   // a map of fn signature with fn from program
-  std::map<llvm::StringRef, const llvm::Function *> analyzed;
+  std::map<std::string, const llvm::Function *> analyzed;
 
   // a set of fn that openrace does not analyze
-  std::vector<llvm::StringRef> unAnalyzed;
+  std::vector<std::string> unAnalyzed;
 };
 
 class Coverage {

--- a/src/Statistics/Coverage.h
+++ b/src/Statistics/Coverage.h
@@ -44,9 +44,6 @@ class Coverage {
   // compute coverage = (#function analyzed in openrace/#function in the whole program IR)
   void computeFnCoverage();
 
-  // compute coverage = (#read and write analyzed in openrace/#read and write in the whole program IR)
-  void computeMemAccessCoverage();
-
  private:
   // compute necessary information in CoverageData
   void summarize();

--- a/src/Statistics/Coverage.h
+++ b/src/Statistics/Coverage.h
@@ -24,12 +24,12 @@ struct CoverageData {
   // a map of fn signature with fn from program
   std::map<std::string, const llvm::Function *> analyzed;
 
-  // a map of fn that openrace does not analyze, and whether it is external
-  std::map<std::string, bool> unAnalyzed;
+  // a set of fn that openrace does not analyze
+  std::set<std::string> unAnalyzed;
 
-  // TODO: are external and unAnalyzedExternal always the same? should be
-  unsigned int external = 0;            // the size of external functions from .bc/.ll
-  unsigned int unAnalyzedExternal = 0;  // the size of unanalyzed external functions
+  // the number of visited __kmpc_fork_call
+  // TODO: simd is a special case which has no omp calls
+  unsigned int numOpenMPRegions = 0;
 };
 
 class Coverage {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,6 +29,9 @@ static llvm::cl::opt<std::string> DumpJSON("json", cl::desc("Dump JSON race repo
 
 static llvm::cl::opt<bool> PrintTrace("print-trace", cl::desc("print the program trace to stdout"), cl::init(true));
 
+static llvm::cl::opt<bool> DoCoverage(
+    "do-cvg", cl::desc("Compute and print the coverage (= analyzed source code/all source code)"), cl::init(true));
+
 int main(int argc, char** argv) {
   llvm::InitLLVM X(argc, argv);
   llvm::cl::ParseCommandLineOptions(argc, argv);
@@ -54,6 +57,7 @@ int main(int argc, char** argv) {
     config.dumpPreprocessedIR = DumpPreproccessedIR;
   }
   config.printTrace = PrintTrace;
+  config.doCoverage = DoCoverage;
 
   auto report = race::detectRaces(module.get(), config);
   if (report.empty()) {

--- a/tests/helpers/ReportChecking.cpp
+++ b/tests/helpers/ReportChecking.cpp
@@ -130,6 +130,7 @@ void checkTest(llvm::StringRef file, llvm::StringRef llPath, std::initializer_li
   // Generate the report
   auto report = race::detectRaces(module.get(), race::DetectRaceConfig{
                                                     .printTrace = false,
+                                                    .doCoverage = false,
                                                 });
 
   // Get actual/expected test races


### PR DESCRIPTION
The coverage includes: 
- #function analyzed in openrace/#function in the whole program IR
- this coverage excludes external functions
- the flag is `-do-cvg` with default value `true`