### PR TITLE
Fix missing called function when call instruction uses alias/bitcast

### DIFF
--- a/src/IR/Builder.cpp
+++ b/src/IR/Builder.cpp
@@ -25,44 +25,6 @@ using namespace race;
 
 extern llvm::cl::opt<bool> DEBUG_PTA;
 
-// callInst might call a function with alias/cast, the same as pta::CallSite::resolveTargetFunction but no const
-// e.g., @_ZN6DomainD1Ev = dso_local unnamed_addr alias void (%class.Domain*), void (%class.Domain*)* @_ZN6DomainD2Ev
-// refer to https://llvm.org/docs/LangRef.html#aliases
-llvm::Function *FunctionSummaryBuilder::resolveTargetFunction(const llvm::CallBase *callInst) {
-  auto calledFunc = callInst->getCalledFunction();
-  if (calledFunc) {
-    if (!calledFunc->hasName()) {
-      llvm::errs() << "could not find called func without name: " << *callInst << "\n";
-      return nullptr;
-    }
-    return calledFunc;
-  }
-
-  llvm::Value *calledValue = callInst->getCalledOperand();
-  if (auto bitcast = llvm::dyn_cast<llvm::BitCastOperator>(calledValue)) {
-    if (auto function = llvm::dyn_cast<llvm::Function>(bitcast->getOperand(0))) {
-      return function;
-    }
-    llvm::errs() << "resolveTargetFunction matched bitcast but symbol was not Function: " << *callInst << "\n";
-  }
-
-  if (auto globalAlias = llvm::dyn_cast<llvm::GlobalAlias>(calledValue)) {
-    auto globalSymbol = globalAlias->getIndirectSymbol()->stripPointerCasts();
-    if (auto function = llvm::dyn_cast<llvm::Function>(globalSymbol)) {
-      return function;
-    }
-    llvm::errs() << "resolveTargetFunction matched globalAlias but symbol was not Function: " << *callInst << "\n";
-  }
-
-  if (llvm::isa<llvm::UndefValue>(calledValue)) {
-    llvm::errs() << "resolveTargetFunction encounter undefvalue: " << *callInst << "\n";
-    return nullptr;
-  }
-
-  llvm::errs() << "Unable to resolveTargetFunction from calledValue: " << *callInst << "\n";
-  return nullptr;
-}
-
 namespace {
 
 // return true if the operand of inst must be a thread local object
@@ -140,10 +102,8 @@ std::shared_ptr<const FunctionSummary> generateFunctionSummary(const llvm::Funct
           continue;
         }
 
-        auto calledFunc = FunctionSummaryBuilder::resolveTargetFunction(callInst);
-        if (calledFunc == nullptr) {
-          continue;
-        } else if (calledFunc->isIntrinsic() || calledFunc->isDebugInfoForProfiling()) {
+        auto calledFunc = CallIR::resolveTargetFunction(callInst);
+        if (calledFunc == nullptr || calledFunc->isIntrinsic() || calledFunc->isDebugInfoForProfiling()) {
           continue;
         }
 

--- a/src/IR/Builder.h
+++ b/src/IR/Builder.h
@@ -29,6 +29,5 @@ class FunctionSummaryBuilder {
 
  public:
   std::shared_ptr<const FunctionSummary> getFunctionSummary(const llvm::Function *func);
-  static llvm::Function *resolveTargetFunction(const llvm::CallBase *callInst);
 };
 }  // namespace race

--- a/src/IR/Builder.h
+++ b/src/IR/Builder.h
@@ -29,5 +29,6 @@ class FunctionSummaryBuilder {
 
  public:
   std::shared_ptr<const FunctionSummary> getFunctionSummary(const llvm::Function *func);
+  static llvm::Function *resolveTargetFunction(const llvm::CallBase *callInst);
 };
 }  // namespace race

--- a/src/IR/IR.h
+++ b/src/IR/IR.h
@@ -226,7 +226,9 @@ class CallIR : public IR {
 
   [[nodiscard]] inline bool isIndirect() const { return inst->isIndirectCall(); }
 
-  [[nodiscard]] virtual const llvm::Function *getCalledFunction() const { return getInst()->getCalledFunction(); }
+  [[nodiscard]] virtual const llvm::Function *getCalledFunction() const { return resolveTargetFunction(getInst()); }
+
+  static llvm::Function *resolveTargetFunction(const llvm::CallBase *callInst);
 
   // Used for llvm style RTTI (isa, dyn_cast, etc.)
   static bool classof(const IR *e) { return e->type >= Type::Call && e->type < Type::END_Call; }

--- a/src/PointerAnalysis/CMDOptions.cpp
+++ b/src/PointerAnalysis/CMDOptions.cpp
@@ -17,7 +17,7 @@ using namespace pta;
 
 // llvm cmd options
 cl::opt<bool> ConfigPrintConstraintGraph("consgraph", cl::desc("Dump Constraint Graph to dot file"));
-cl::opt<bool> ConfigPrintCallGraph("callgraph", cl::desc("Dump SHB graph to dot file"));
+cl::opt<bool> ConfigPrintCallGraph("callgraph", cl::desc("Dump call graph to dot file"));
 cl::opt<bool> ConfigDumpPointsToSet("dump-pts", cl::desc("Dump the Points-to Set of every pointer"));
 cl::opt<bool> USE_MEMLAYOUT_FILTERING(
     "Xmemlayout-filtering", cl::desc("Use memory layout to filter out incompatible types in field-sensitive PTA"));

--- a/src/Trace/ThreadTrace.cpp
+++ b/src/Trace/ThreadTrace.cpp
@@ -224,11 +224,16 @@ void traverseCallNode(const pta::CallGraphNodeTy *node, ThreadTrace &thread, Cal
       }
 
       auto directContext = pta::CT::contextEvolve(context, ir->getInst());
-      auto const directNode = pta.getDirectNodeOrNull(directContext, call->getCalledFunction());
+      auto callee = FunctionSummaryBuilder::resolveTargetFunction(call->getInst());
+      if (callee == nullptr) {
+        continue;
+      }
 
+      auto const directNode = pta.getDirectNodeOrNull(directContext, callee);
       if (directNode == nullptr) {
         // TODO: LOG unable to get child node
-        llvm::errs() << "Unable to get child node: " << call->getCalledFunction()->getName() << "\n";
+        llvm::errs() << "Unable to get child node: " << call->getCalledFunction()->getName() << "from "
+                     << *ir->getInst() << "\n";
         continue;
       }
 

--- a/src/Trace/ThreadTrace.cpp
+++ b/src/Trace/ThreadTrace.cpp
@@ -224,8 +224,8 @@ void traverseCallNode(const pta::CallGraphNodeTy *node, ThreadTrace &thread, Cal
       }
 
       auto directContext = pta::CT::contextEvolve(context, ir->getInst());
-      auto callee = FunctionSummaryBuilder::resolveTargetFunction(call->getInst());
-      if (callee == nullptr) {
+      auto callee = CallIR::resolveTargetFunction(call->getInst());
+      if (callee == nullptr || callee->isIntrinsic() || callee->isDebugInfoForProfiling()) {
         continue;
       }
 


### PR DESCRIPTION
Fix the missing called functions triggered by https://github.com/coderrect-inc/OpenRace/blob/1edb5fa6f70d5fa49af6d5e15cc1f3bb0d0f5342/src/Trace/ThreadTrace.cpp#L229-L233

Happen when running Lulesh.

It is because the call instruction uses global alias or bit cast, e.g.,
```
@_ZN6DomainD1Ev = dso_local unnamed_addr alias void (%class.Domain*), void (%class.Domain*)* @_ZN6DomainD2Ev
```
so,
```
callInst->getCalledFunction() == nullptr
```