### PR TITLE
Skip all the instructions in the main thread before we reach a fork/s…

### DIFF
--- a/src/IR/Builder.cpp
+++ b/src/IR/Builder.cpp
@@ -100,7 +100,7 @@ std::shared_ptr<const FunctionSummary> generateFunctionSummary(const llvm::Funct
         }
 
         auto calledFunc = CallIR::resolveTargetFunction(callInst);
-        if (calledFunc == nullptr || calledFunc->isIntrinsic() || calledFunc->isDebugInfoForProfiling()) {
+        if (calledFunc == nullptr) {
           continue;
         }
 

--- a/src/IR/IR.cpp
+++ b/src/IR/IR.cpp
@@ -159,3 +159,14 @@ llvm::Function *CallIR::resolveTargetFunction(const llvm::CallBase *callInst) {
   }
   return calledFunc;
 }
+
+// return true if typ is a IR Type that fork a new thread
+bool IR::isForkType(const IR::Type typ) {
+  return typ == IR::Type::PthreadCreate || typ == IR::Type::OpenMPFork || typ == IR::Type::OpenMPForkTeams;
+}
+
+// return true if typ is a IR Type of lock or guard, e.g., omp_get_thread_num, single
+// AND it may happen before reaching any forks
+bool IR::isLockGuardTypeBeforeReachingParallel(const IR::Type typ) {
+  return typ == IR::Type::PthreadMutexLock || typ == IR::Type::PthreadSpinLock || typ == IR::Type::OpenMPGetThreadNum;
+}

--- a/src/IR/IR.h
+++ b/src/IR/IR.h
@@ -80,6 +80,9 @@ class IR {
   [[nodiscard]] virtual llvm::StringRef toString() const;
   virtual void print(llvm::raw_ostream &os) const = 0;
 
+  static bool isForkType(const IR::Type typ);
+  static bool isLockGuardTypeBeforeReachingParallel(const IR::Type typ);
+
   virtual ~IR() = default;
 
  protected:

--- a/src/RaceDetect.cpp
+++ b/src/RaceDetect.cpp
@@ -24,7 +24,7 @@ limitations under the License.
 using namespace race;
 
 Report race::detectRaces(llvm::Module *module, DetectRaceConfig config) {
-  race::ProgramTrace program(module);
+  race::ProgramTrace program(module, config.skilUntilFork);
 
   if (config.dumpPreprocessedIR.has_value()) {
     std::error_code err;

--- a/src/RaceDetect.h
+++ b/src/RaceDetect.h
@@ -24,6 +24,9 @@ struct DetectRaceConfig {
 
   // Compute and print the coverage (= analyzed source code/all source code)
   bool doCoverage = false;
+
+  // Skip all the instructions in the main thread before we reach a fork/spawn/other interesting IR
+  bool skilUntilFork = false;
 };
 
 Report detectRaces(llvm::Module *module, DetectRaceConfig config = DetectRaceConfig());

--- a/src/Trace/ProgramTrace.cpp
+++ b/src/Trace/ProgramTrace.cpp
@@ -16,7 +16,8 @@ limitations under the License.
 
 using namespace race;
 
-ProgramTrace::ProgramTrace(llvm::Module *module, llvm::StringRef entryName) : module(module) {
+ProgramTrace::ProgramTrace(llvm::Module *module, bool skipUntilFork, llvm::StringRef entryName)
+    : module(module), skipUntilFork(skipUntilFork) {
   // Run preprocessing on module
   preprocess(*module);
 
@@ -24,6 +25,7 @@ ProgramTrace::ProgramTrace(llvm::Module *module, llvm::StringRef entryName) : mo
   pta.analyze(module, entryName);
 
   TraceBuildState state;
+  state.startRecord = !skipUntilFork;
 
   // build all threads starting from this main func
   auto const mainEntry = pta::GT::getEntryNode(pta.getCallGraph());

--- a/src/Trace/ProgramTrace.h
+++ b/src/Trace/ProgramTrace.h
@@ -73,6 +73,10 @@ struct TraceBuildState {
   // pState.threads.size() will be updated after finishing the construction, we need such a counter
   ThreadID currentTID = 0;
 
+  // whether we reach a meaningful IR in the main thread that relates to/starts multi-threads,
+  // e.g., lock, pthread_create, openmp fork, etc.
+  bool startRecord = false;
+
   // When set, skip traversing until this instruction is reached
   const llvm::Instruction *skipUntil = nullptr;
 
@@ -89,6 +93,7 @@ class ProgramTrace {
 
  public:
   pta::PTA pta;
+  bool skipUntilFork;
 
   [[nodiscard]] inline const std::vector<const ThreadTrace *> &getThreads() const { return threads; }
 
@@ -97,7 +102,7 @@ class ProgramTrace {
   // Get the module after preprocessing has been run
   [[nodiscard]] const Module &getModule() const { return *module; }
 
-  explicit ProgramTrace(llvm::Module *module, llvm::StringRef entryName = "main");
+  explicit ProgramTrace(llvm::Module *module, bool skipUntilFork = true, llvm::StringRef entryName = "main");
   ~ProgramTrace() = default;
   ProgramTrace(const ProgramTrace &) = delete;
   ProgramTrace(ProgramTrace &&) = delete;  // Need to update threads because

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,6 +32,10 @@ static llvm::cl::opt<bool> PrintTrace("print-trace", cl::desc("print the program
 static llvm::cl::opt<bool> DoCoverage(
     "do-cvg", cl::desc("Compute and print the coverage (= analyzed source code/all source code)"), cl::init(true));
 
+static llvm::cl::opt<bool> SkipUntilFork(
+    "skip", cl::desc("Skip all the instructions in the main thread before we reach a fork/spawn/other interesting IR"),
+    cl::init(true));
+
 int main(int argc, char** argv) {
   llvm::InitLLVM X(argc, argv);
   llvm::cl::ParseCommandLineOptions(argc, argv);
@@ -58,6 +62,7 @@ int main(int argc, char** argv) {
   }
   config.printTrace = PrintTrace;
   config.doCoverage = DoCoverage;
+  config.skilUntilFork = SkipUntilFork;
 
   auto report = race::detectRaces(module.get(), config);
   if (report.empty()) {

--- a/tests/unit/Analysis/HappensBefore.test.cpp
+++ b/tests/unit/Analysis/HappensBefore.test.cpp
@@ -46,7 +46,7 @@ declare i32 @pthread_join(i64, i8**)
     Err.print("error", llvm::errs());
   }
 
-  race::ProgramTrace program(module.get(), "foo");
+  race::ProgramTrace program(module.get(), true, "foo");
 
   race::HappensBeforeGraph happensbefore(program);
 

--- a/tests/unit/Analysis/LockSet.test.cpp
+++ b/tests/unit/Analysis/LockSet.test.cpp
@@ -9,11 +9,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#include "Analysis/LockSet.h"
+
 #include <llvm/AsmParser/Parser.h>
 
 #include <catch2/catch.hpp>
-
-#include "Analysis/LockSet.h"
 
 // TODO: really need way to construct and eval trace for testing, not reading IR
 TEST_CASE("Simple lockset test", "[unit][lockset]") {
@@ -61,7 +61,7 @@ declare i32 @pthread_mutex_unlock(%union.pthread_mutex_t*) #1
     Err.print("error", llvm::errs());
   }
 
-  race::ProgramTrace program(module.get());
+  race::ProgramTrace program(module.get(), false);
 
   auto const &threads = program.getThreads();
   REQUIRE(threads.size() == 1);

--- a/tests/unit/Analysis/SharedMemory.test.cpp
+++ b/tests/unit/Analysis/SharedMemory.test.cpp
@@ -9,11 +9,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#include "Analysis/SharedMemory.h"
+
 #include <llvm/AsmParser/Parser.h>
 
 #include <catch2/catch.hpp>
 
-#include "Analysis/SharedMemory.h"
 #include "Trace/ProgramTrace.h"
 
 TEST_CASE("Construct SharedMemory from real Program", "[unit][sharedmemory]") {
@@ -47,6 +48,6 @@ declare i32 @pthread_join(i64, i8**)
     Err.print("error", llvm::errs());
   }
 
-  race::ProgramTrace program(module.get(), "foo");
+  race::ProgramTrace program(module.get(), true, "foo");
   race::SharedMemory sharedmem(program);
 }

--- a/tests/unit/Trace/Trace.test.cpp
+++ b/tests/unit/Trace/Trace.test.cpp
@@ -42,7 +42,7 @@ define void @foo() {
   llvm::SMDiagnostic Err;
   auto module = llvm::parseAssemblyString(modString, Err, Ctx);
 
-  race::ProgramTrace program(module.get(), "foo");
+  race::ProgramTrace program(module.get(), false, "foo");
   auto const &threads = program.getThreads();
   REQUIRE(threads.size() == 1);
 
@@ -88,7 +88,7 @@ declare i32 @pthread_join(i64, i8**)
     Err.print("error", llvm::errs());
   }
 
-  race::ProgramTrace program(module.get(), "foo");
+  race::ProgramTrace program(module.get(), true, "foo");
   auto const &threads = program.getThreads();
   REQUIRE(threads.size() == 2);
 
@@ -164,7 +164,7 @@ declare i32 @pthread_join(i64, i8**)
     Err.print("error", llvm::errs());
   }
 
-  race::ProgramTrace program(module.get(), "foo");
+  race::ProgramTrace program(module.get(), true, "foo");
   auto const &threads = program.getThreads();
   REQUIRE(threads.size() == 3);
 
@@ -225,7 +225,7 @@ declare i32 @pthread_mutex_unlock(%union.pthread_mutex_t*) #1
     Err.print("error", llvm::errs());
   }
 
-  race::ProgramTrace program(module.get());
+  race::ProgramTrace program(module.get(), false);
   auto const &threads = program.getThreads();
   REQUIRE(threads.size() == 1);
 


### PR DESCRIPTION
Fix the 3rd problem in issue #314.

Skip all the instructions in the main thread before we reach a fork/spawn/other interesting IR, when building `ThreadTrace`. Also added a flag `skip` for users and to pass the following tests, e.g., 
```
          1 - Happens Before Graph 
          3 - Simple lockset test 
          4 - Construct SharedMemory from real Program 
         19 - ThreadTrace construction 
         20 - Construct pthread ThreadTrace 
         21 - Nested Pthread ThreadTrace 
         22 - Construct mutex ThreadTrace 
```
