### PR TITLE
Add simple structs and logics to track HB/Lock state with tests

### DIFF
--- a/src/Trace/ProgramTrace.h
+++ b/src/Trace/ProgramTrace.h
@@ -12,11 +12,12 @@ limitations under the License.
 #pragma once
 
 #include <IR/Builder.h>
+#include <llvm/ADT/DenseMap.h>
 
 #include <vector>
 
 #include "IR/IRImpls.h"
-#include "LanguageModel/RaceModel.h"
+//#include "LanguageModel/RaceModel.h"
 #include "ThreadTrace.h"
 #include "Trace/Event.h"
 
@@ -64,6 +65,145 @@ struct OpenMPState {
   std::vector<UnjoinedTask> unjoinedTasks;
 };
 
+// record a HB state: current belonging thread + [ a list of seen fork/join events ]
+struct HBState {
+  std::vector<EventID> forkjoins;
+
+  HBState(std::vector<EventID> forkjoins) { this->forkjoins.assign(forkjoins.begin(), forkjoins.end()); };
+
+  bool operator==(const HBState &other) const {
+    return forkjoins.size() == other.forkjoins.size() &&
+           std::equal(forkjoins.begin(), forkjoins.end(), other.forkjoins.begin());
+  }
+};
+
+// record a state of a specific combination of HB relation and lockset
+struct LockState {
+  std::vector<EventID> lockset;  // a set of held/released locks
+
+  LockState(std::vector<EventID> lockset) { this->lockset.assign(lockset.begin(), lockset.end()); };
+
+  bool operator==(const LockState &other) const {
+    return lockset.size() == other.lockset.size() && std::equal(lockset.begin(), lockset.end(), other.lockset.begin());
+  }
+};
+
+struct HBLockState {
+  const ThreadID myTID;
+
+  // track the interesting events during building the thread traces for myTID
+  std::vector<EventID> forkJoinEvents;
+  std::vector<EventID> lockEvents;
+
+  // the current states
+  const HBState *curHB = nullptr;
+  const LockState *curLock = nullptr;
+
+  // use both HBState and LockState as the key
+  using KeyType = std::pair<const HBState *, const LockState *>;
+  llvm::DenseMap<KeyType, std::vector<const llvm::Function *> *> state2fn;
+
+  HBLockState(ThreadID tid) : myTID(tid) {
+    curHB = new HBState(forkJoinEvents);
+    curLock = new LockState(lockEvents);
+  };
+
+  // push into forkJoinEvents/lockEvents to track current state
+  void updateEvent(EventID eid, Event::Type typ) {
+    switch (typ) {
+      case Event::Type::Fork:
+      case Event::Type::Join:
+      case Event::Type::Barrier: {
+        forkJoinEvents.push_back(eid);
+        curHB = new HBState(forkJoinEvents);
+        break;
+      }
+      case Event::Type::Lock:
+      case Event::Type::Unlock: {
+        lockEvents.push_back(eid);
+        curLock = new LockState(lockEvents);
+        break;
+      }
+      default:
+        llvm::errs() << "Should not call HBLockState::updateEvent for " << typ << "\n";
+        break;
+    }
+  }
+
+  // return true if state2fn has the key (curHB + curLock) for func
+  bool existHBLockStateFor(const llvm::Function *func) {
+    auto key = std::make_pair(curHB, curLock);
+    auto it = state2fn.find(key);
+    if (it == state2fn.end()) {  // no such key
+      std::vector<const llvm::Function *> *traversedFuncs = new std::vector<const llvm::Function *>();
+      traversedFuncs->push_back(func);
+      state2fn.insert(std::make_pair(key, traversedFuncs));
+      return false;
+    }
+
+    auto traversedFuncs = it->second;
+    bool found = std::find(traversedFuncs->begin(), traversedFuncs->end(), func) != traversedFuncs->end();
+    if (!found) {  // not traversed function for such a state yet
+      traversedFuncs->push_back(func);
+    }
+
+    return found;
+  }
+
+  // clear/release all allocated memory here
+  void clear() {
+    forkJoinEvents.resize(0);  // or use .clear() ?
+    forkJoinEvents.shrink_to_fit();
+    lockEvents.resize(0);
+    lockEvents.shrink_to_fit();
+    curLock = nullptr;
+    curHB = nullptr;
+    state2fn.shrink_and_clear();
+  }
+};
+
+struct TraversalState {
+  // the HB and lockset state that already recorded
+  std::map<const ThreadID, HBLockState *> traversedStates;
+
+  // the HBLockState for the thread id that we are currently building for
+  HBLockState *curState = nullptr;
+
+  void findOrCreateCurState(const ThreadID tid) {
+    auto it = traversedStates.find(tid);
+    if (it == traversedStates.end()) {
+      curState = new HBLockState(tid);
+      traversedStates.insert(std::make_pair(tid, curState));
+    } else {
+      assert(it->first == tid);
+      curState = it->second;
+    }
+  }
+
+  // return true if we already traversedStates func for current HB and Lockset state
+  bool existStateForFunc(const ThreadID tid, const llvm::Function *func) {
+    if (curState == nullptr || curState->myTID != tid) {
+      findOrCreateCurState(tid);
+    }
+    return curState->existHBLockStateFor(func);
+  }
+
+  // push into forkJoinEvents/lockEvents in HBLockState for tid to track its current state
+  void updateEvent(const ThreadID tid, EventID eid, Event::Type typ) {
+    if (curState == nullptr || curState->myTID != tid) {
+      findOrCreateCurState(tid);
+    }
+    curState->updateEvent(eid, typ);
+  }
+
+  // remove the record from traversedStates when the build of thread trace is finished
+  void removeStateFor(const ThreadID tid) {
+    curState->clear();
+    curState = nullptr;
+    traversedStates.erase(tid);
+  }
+};
+
 // all included states are ONLY used when building ProgramTrace/ThreadTrace
 struct TraceBuildState {
   // Cached function summaries
@@ -78,6 +218,9 @@ struct TraceBuildState {
 
   // Track state specific to OpenMP
   OpenMPState openmp;
+
+  // Track the state of HB relation and lockset for each traversed function
+  TraversalState traversal;
 };
 
 class ProgramTrace {

--- a/src/Trace/ProgramTrace.h
+++ b/src/Trace/ProgramTrace.h
@@ -119,7 +119,8 @@ struct HBLockState {
         break;
       }
       case Event::Type::Lock:
-      case Event::Type::Unlock: {
+      case Event::Type::Unlock:
+      case Event::Type::ExternCall: {  // the guards treats like locks
         lockEvents.push_back(eid);
         curLock = new LockState(lockEvents);
         break;

--- a/src/Trace/ProgramTrace.h
+++ b/src/Trace/ProgramTrace.h
@@ -152,7 +152,8 @@ struct HBLockState {
 
   // clear/release all allocated memory here
   void clear() {
-    forkJoinEvents.resize(0);  // or use .clear() ?
+    // or use .clear() ?
+    forkJoinEvents.resize(0);
     forkJoinEvents.shrink_to_fit();
     lockEvents.resize(0);
     lockEvents.shrink_to_fit();
@@ -198,6 +199,9 @@ struct TraversalState {
 
   // remove the record from traversedStates when the build of thread trace is finished
   void removeStateFor(const ThreadID tid) {
+    if (curState == nullptr || curState->myTID != tid) {
+      findOrCreateCurState(tid);
+    }
     curState->clear();
     curState = nullptr;
     traversedStates.erase(tid);

--- a/src/Trace/ThreadTrace.cpp
+++ b/src/Trace/ThreadTrace.cpp
@@ -254,6 +254,10 @@ void traverseCallNode(const pta::CallGraphNodeTy *node, ThreadTrace &thread, Cal
 
       if (directNode->getTargetFun()->isExtFunction()) {
         events.push_back(std::make_unique<ExternCallEventImpl>(call, einfo, events.size()));
+        if (callIR->type == IR::Type::OpenMPGetThreadNumGuardStart ||
+            callIR->type == IR::Type::OpenMPGetThreadNumGuardEnd) {
+          state.traversal.updateEvent(thread.id, events.size() - 1, Event::Type::ExternCall);
+        }
         continue;
       }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,17 +14,18 @@ add_executable(tester
     unit/Trace/CallStack.test.cpp
     unit/Trace/Trace.test.cpp
     unit/Trace/OpenMPTrace.test.cpp
+    unit/Opt/Opt.test.cpp
     
     integration/pthreadrace.test.cpp
     integration/dataracebench.test.cpp
     integration/openmp.test.cpp
+    integration/optimization.test.cpp
 
     regression/EmptyThread.test.cpp
     regression/OpenMPRegression.test.cpp
 
     # Helper logic
-    helpers/ReportChecking.cpp
-)
+    helpers/ReportChecking.cpp)
 target_link_libraries(tester pta racedetect-lib ${llvm_libs} CONAN_PKG::catch2)
 target_include_directories(tester PRIVATE ${LLVM_INCLUDE_DIRS})
 target_include_directories(tester PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/tests/data/Makefile
+++ b/tests/data/Makefile
@@ -23,7 +23,7 @@ all: unit integration
 
 unit: unit/Analysis/simpleloop.ll
 
-integration: dataracebench pthreadrace openmp
+integration: dataracebench pthreadrace openmp optimization
 
 DRB_C_SRC=$(wildcard integration/dataracebench/*.c)
 DRB_C_OUT=$(DRB_C_SRC:.c=.ll)
@@ -41,6 +41,10 @@ OMP_SRC=$(wildcard integration/openmp/*.c)
 OMP_OUT=$(OMP_SRC:.c=.ll)
 openmp: $(OMP_OUT)
 
+OPT_SRC=$(wildcard integration/optimization/*.c)
+OPT_OUT=$(OPT_SRC:.c=.ll)
+optimization: $(OPT_OUT)
+
 clean:
-	@rm -f $(PTHREAD_C_OUT) $(PTHREAD_CXX_OUT) $(DRB_C_OUT) $(DRB_CXX_OUT) $(OMP_OUT)
+	@rm -f $(PTHREAD_C_OUT) $(PTHREAD_CXX_OUT) $(DRB_C_OUT) $(DRB_CXX_OUT) $(OMP_OUT) $(OPT_OUT)
 	

--- a/tests/data/integration/optimization/omp-get-thread-num-duplicate-call.c
+++ b/tests/data/integration/optimization/omp-get-thread-num-duplicate-call.c
@@ -12,9 +12,9 @@ int main() {
 
     if (tid == 1) {
       write_val(&counter, tid);
-      write_val(&counter, tid);
+      write_val(&counter, tid);  // this should be skipped
     }
-    write_val(&counter, tid);
+    write_val(&counter, tid);  // this should not be skipped
   }
 
   printf("%d\n", counter);

--- a/tests/data/integration/optimization/omp-get-thread-num-duplicate-call.c
+++ b/tests/data/integration/optimization/omp-get-thread-num-duplicate-call.c
@@ -1,0 +1,21 @@
+#include <omp.h>
+#include <stdio.h>
+
+void write_val(int *dest, int val) { *dest = val; }
+
+int main() {
+  int counter = 0;
+
+#pragma omp parallel
+  {
+    int tid = omp_get_thread_num();
+
+    if (tid == 1) {
+      write_val(&counter, tid);
+      write_val(&counter, tid);
+    }
+    write_val(&counter, tid);
+  }
+
+  printf("%d\n", counter);
+}

--- a/tests/data/integration/optimization/simple-duplicate-call.c
+++ b/tests/data/integration/optimization/simple-duplicate-call.c
@@ -1,0 +1,17 @@
+#include <omp.h>
+#include <stdio.h>
+
+void write_val(int *dest, int val) { *dest = val; }
+
+int main() {
+  int counter = 0;
+  int tid = 1;
+
+#pragma omp parallel
+  {
+    write_val(&counter, tid);
+    write_val(&counter, tid);
+  }
+
+  printf("%d\n", counter);
+}

--- a/tests/data/integration/optimization/simple-duplicate-call.c
+++ b/tests/data/integration/optimization/simple-duplicate-call.c
@@ -10,7 +10,7 @@ int main() {
 #pragma omp parallel
   {
     write_val(&counter, tid);
-    write_val(&counter, tid);
+    write_val(&counter, tid);  // this should be skipped
   }
 
   printf("%d\n", counter);

--- a/tests/integration/optimization.test.cpp
+++ b/tests/integration/optimization.test.cpp
@@ -1,0 +1,26 @@
+/* Copyright 2021 Coderrect Inc. All Rights Reserved.
+Licensed under the GNU Affero General Public License, version 3 or later (“AGPL”), as published by the Free Software
+Foundation. You may not use this file except in compliance with the License. You may obtain a copy of the License at
+https://www.gnu.org/licenses/agpl-3.0.en.html
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an “AS IS” BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <catch2/catch.hpp>
+
+#include "helpers/ReportChecking.h"
+
+#define TEST_LL(name, file, ...) \
+  TEST_CASE(name, "[integration][opt]") { checkTest(file, "integration/optimization/", {__VA_ARGS__}); }
+
+#define EXPECTED(...) __VA_ARGS__
+#define NORACE
+
+// Avoid duplicate function traversal during building thread traces
+TEST_LL("simple-duplicate-call", "simple-duplicate-call.ll",
+        EXPECTED("simple-duplicate-call.c:4:44 simple-duplicate-call.c:4:44"))
+TEST_LL("omp-get-thread-num-duplicate-call", "omp-get-thread-num-duplicate-call.ll",
+        EXPECTED("omp-get-thread-num-duplicate-call.c:4:44 omp-get-thread-num-duplicate-call.c:4:44"))

--- a/tests/unit/Opt/Opt.test.cpp
+++ b/tests/unit/Opt/Opt.test.cpp
@@ -1,0 +1,11 @@
+/* Copyright 2021 Coderrect Inc. All Rights Reserved.
+Licensed under the GNU Affero General Public License, version 3 or later (“AGPL”), as published by the Free Software
+Foundation. You may not use this file except in compliance with the License. You may obtain a copy of the License at
+https://www.gnu.org/licenses/agpl-3.0.en.html
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an “AS IS” BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+

--- a/tests/unit/Opt/Opt.test.cpp
+++ b/tests/unit/Opt/Opt.test.cpp
@@ -9,3 +9,67 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#include <llvm/AsmParser/Parser.h>
+#include <llvm/IR/LLVMContext.h>
+#include <llvm/IR/Module.h>
+#include <llvm/IRReader/IRReader.h>
+
+#include <catch2/catch.hpp>
+
+#include "Analysis/LockSet.h"
+
+TEST_CASE("Simple optimization test (avoid duplicate calls)", "[unit]") {
+  llvm::LLVMContext context;
+  llvm::SMDiagnostic err;
+  llvm::StringRef file = "simple-duplicate-call.ll";
+  llvm::StringRef llPath = "integration/optimization/";
+
+  // Read the input file
+  auto testfile = llPath.str() + file.str();
+  auto module = llvm::parseIRFile(testfile, err, context);
+  if (!module) {
+    err.print(file.str().c_str(), llvm::errs());
+  }
+  REQUIRE(module.get() != nullptr);
+
+  race::ProgramTrace program(module.get());
+
+  auto const &threads = program.getThreads();
+  REQUIRE(threads.size() == 3);
+
+  auto const &thread1 = threads.at(1);
+  auto const &events1 = thread1->getEvents();
+  REQUIRE(events1.size() == 5);
+
+  auto const &thread2 = threads.at(2);
+  auto const &events2 = thread2->getEvents();
+  REQUIRE(events2.size() == 5);
+}
+
+TEST_CASE("Optimization test with guards (avoid duplicate calls)", "[unit]") {
+  llvm::LLVMContext context;
+  llvm::SMDiagnostic err;
+  llvm::StringRef file = "omp-get-thread-num-duplicate-call.ll";
+  llvm::StringRef llPath = "integration/optimization/";
+
+  // Read the input file
+  auto testfile = llPath.str() + file.str();
+  auto module = llvm::parseIRFile(testfile, err, context);
+  if (!module) {
+    err.print(file.str().c_str(), llvm::errs());
+  }
+  REQUIRE(module.get() != nullptr);
+
+  race::ProgramTrace program(module.get());
+
+  auto const &threads = program.getThreads();
+  REQUIRE(threads.size() == 3);
+
+  auto const &thread1 = threads.at(1);
+  auto const &events1 = thread1->getEvents();
+  REQUIRE(events1.size() == 9);
+
+  auto const &thread2 = threads.at(2);
+  auto const &events2 = thread2->getEvents();
+  REQUIRE(events2.size() == 9);
+}


### PR DESCRIPTION
Fix the 2nd problem in issue #314: avoid repetitively traveling the same call chains.