### PR TITLE
Avoid recursive thread trace creation

### DIFF
--- a/src/Trace/ProgramTrace.h
+++ b/src/Trace/ProgramTrace.h
@@ -78,6 +78,21 @@ struct TraceBuildState {
 
   // Track state specific to OpenMP
   OpenMPState openmp;
+
+  // a set of traversed cgnodes which fork threads
+  std::set<const pta::CallGraphNodeTy *> traversedForkCGNodes;
+
+  // return true if this node has already been traversed
+  bool skipThisCallGraphNode(const pta::CallGraphNodeTy *node) {
+    if (traversedForkCGNodes.find(node) == traversedForkCGNodes.end()) {
+      traversedForkCGNodes.insert(node);
+      return false;
+    }
+    return true;
+  }
+
+  // return true if we already skip the corresponding fork traversal for this join
+  bool skipThisJoin() {}
 };
 
 class ProgramTrace {

--- a/src/Trace/ThreadTrace.cpp
+++ b/src/Trace/ThreadTrace.cpp
@@ -183,6 +183,8 @@ void traverseCallNode(const pta::CallGraphNodeTy *node, ThreadTrace &thread, Cal
       // TODO: log if entries contained more than one possible entry
       auto entry = entries.front();
 
+      if (state.skipThisCallGraphNode(entry)) continue;
+
       // build thread trace for this fork and all sub threads
       auto childThread = std::make_unique<ThreadTrace>(forkEvent, entry, state);
       threads.push_back(std::move(childThread));


### PR DESCRIPTION
Fix the 1st problem in issue #314. This also skips the corresponding join, currently only consider `pthread` and `omp fork`.