### PR TITLE
Better reporter

### DIFF
--- a/src/Reporter/Reporter.cpp
+++ b/src/Reporter/Reporter.cpp
@@ -49,13 +49,13 @@ llvm::raw_ostream &race::operator<<(llvm::raw_ostream &os, const SourceLoc &loc)
   return os;
 }
 
-ReportCall::ReportCall(const llvm::CallBase *callBase) : call(std::nullopt), loc(getSourceLoc(callBase)) {
+CallSignature::CallSignature(const llvm::CallBase *callBase) : call(std::nullopt), loc(getSourceLoc(callBase)) {
   if (callBase->getCalledFunction()->hasName()) {
     call = callBase->getCalledFunction()->getName();
   }
 }
 
-llvm::raw_ostream &race::operator<<(llvm::raw_ostream &os, const ReportCall &call) {
+llvm::raw_ostream &race::operator<<(llvm::raw_ostream &os, const CallSignature &call) {
   os << (call.call ? call.call.value() : "UnamedFunc") << " (";
   if (call.loc) {
     os << call.loc;
@@ -67,8 +67,8 @@ llvm::raw_ostream &race::operator<<(llvm::raw_ostream &os, const ReportCall &cal
 }
 
 namespace {
-std::vector<ReportCall> computeCallstack(const Event *targetEvent) {
-  std::vector<ReportCall> callstack;
+std::vector<CallSignature> computeCallstack(const Event *targetEvent) {
+  std::vector<CallSignature> callstack;
 
   auto const &thread = targetEvent->getThread();
   auto const &events = thread.getEvents();

--- a/src/Reporter/Reporter.h
+++ b/src/Reporter/Reporter.h
@@ -51,6 +51,15 @@ void to_json(json &j, const SourceLoc &loc);
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const SourceLoc &loc);
 
+// Store ifnormation about a funciton call and its location in the source. Used to dsiplay callstack in report
+struct ReportCall {
+  std::optional<std::string> call;
+  std::optional<SourceLoc> loc;
+
+  explicit ReportCall(const llvm::CallBase *callBase);
+};
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const ReportCall &call);
+
 // TODO: for now, RaceAccess only has `inst` in addition to SourceLoc, mostly for debugging purpose.
 // We need to include other debugging information, such as stacktrace in the future
 struct RaceAccess {
@@ -58,6 +67,7 @@ struct RaceAccess {
   std::optional<SourceLoc> location;
   Event::Type type;
   const llvm::Instruction *inst;
+  std::vector<ReportCall> callstack;
 
   RaceAccess(const MemAccessEvent *event);
 

--- a/src/Reporter/Reporter.h
+++ b/src/Reporter/Reporter.h
@@ -52,13 +52,13 @@ void to_json(json &j, const SourceLoc &loc);
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const SourceLoc &loc);
 
 // Store ifnormation about a funciton call and its location in the source. Used to dsiplay callstack in report
-struct ReportCall {
+struct CallSignature {
   std::optional<std::string> call;
   std::optional<SourceLoc> loc;
 
-  explicit ReportCall(const llvm::CallBase *callBase);
+  explicit CallSignature(const llvm::CallBase *callBase);
 };
-llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const ReportCall &call);
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const CallSignature &call);
 
 // TODO: for now, RaceAccess only has `inst` in addition to SourceLoc, mostly for debugging purpose.
 // We need to include other debugging information, such as stacktrace in the future
@@ -67,7 +67,7 @@ struct RaceAccess {
   std::optional<SourceLoc> location;
   Event::Type type;
   const llvm::Instruction *inst;
-  std::vector<ReportCall> callstack;
+  std::vector<CallSignature> callstack;
 
   RaceAccess(const MemAccessEvent *event);
 


### PR DESCRIPTION
Change the format of the race reports to be slightly more user friendly.

Added the callstack and source line for each racing access.

Here is an example of a new race report:
```shell
integration/dataracebench/DRB111-linearmissing-orig-yes.c:67:9 integration/dataracebench/DRB111-linearmissing-orig-yes.c:67:9
        ---Source Code---
        67|     c[j]+=a[i]*b[i];
        67|     c[j]+=a[i]*b[i];
        ---LLVM IR---
          store double %add17.i, double* %20, align 8, !dbg !74, !tbaa !68, !noalias !32
          store double %add17.i, double* %20, align 8, !dbg !74, !tbaa !68, !noalias !32
        ---Callstacks---
        > __kmpc_fork_call (integration/dataracebench/DRB111-linearmissing-orig-yes.c:64:1)
        ====
        > __kmpc_fork_call (integration/dataracebench/DRB111-linearmissing-orig-yes.c:64:1)
```

Eventually we will probably write a dedicated tool for displaying the results in a beautiful way.
For now this is a mix of user and developer friendly until we make a full blow report display tool.