### PR TITLE
only run codedov on develop branch

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -47,27 +47,8 @@ jobs:
       - name: Build
         run: |
           mkdir build && cd build
-          cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=g++ -DCODE_COVERAGE=On -DLLVM_INSTALL=/usr/local ..
+          cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=g++ -DLLVM_INSTALL=/usr/local ..
           cmake --build . --parallel
-      
-      - name: Test
-        run: |
-          cd build
-          ctest --parallel $(nproc)
-
-      - name: Generate Coverage Report
-        run: |
-          apt-get -y update
-          apt-get install -y lcov
-          cd build
-          lcov --directory . --capture --output-file my_prog1.info
-          lcov --remove my_prog1.info "*/tests/*" -o my_prog.info
-
-      - name: Upload Coverage
-        uses: codecov/codecov-action@v2
-        with:
-          files: ./build/my_prog.info 
-          verbose: true
   
   formatting-check:
     name: Formatting Check

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -44,10 +44,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      -name: install gcc-10
+        run: |
+          apt-get -y update
+          apt-get install -y g++-10
+
       - name: Build
         run: |
           mkdir build && cd build
-          cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=g++ -DLLVM_INSTALL=/usr/local ..
+          cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=g++-10 -DLLVM_INSTALL=/usr/local ..
           cmake --build . --parallel
   
   formatting-check:

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -44,7 +44,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      -name: install gcc-10
+      - name: install gcc-10
         run: |
           apt-get -y update
           apt-get install -y g++-10

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,0 +1,47 @@
+name: codecov
+
+on:
+  pull_request:
+    branches:
+      - develop
+    paths:
+      - '.github/workflows/codecov.yml'
+  push:
+    branches:
+      - develop
+    paths:
+      - 'src/**'
+      - 'tests/**'
+
+jobs:
+  codecov:
+    runs-on: ubuntu-latest
+    container: coderrect/openrace-env
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build
+        run: |
+          mkdir build && cd build
+          cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=g++ -DCODE_COVERAGE=On -DLLVM_INSTALL=/usr/local ..
+          cmake --build . --parallel
+      
+      - name: Run Tests
+        run: |
+          cd build
+          ctest --parallel $(nproc)
+
+      - name: Generate Coverage Report
+        run: |
+          apt-get -y update
+          apt-get install -y lcov
+          cd build
+          lcov --directory . --capture --output-file openrace-coverage-full.info
+          lcov --remove openrace-coverage-full.info "*/tests/*" -o openrace-coverage.info
+
+      - name: Upload Coverage
+        uses: codecov/codecov-action@v2
+        with:
+          files: ./build/openrace-coverage.info 
+          verbose: true

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -21,10 +21,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      -name: install gcc-10
+        run: |
+          apt-get -y update
+          apt-get install -y g++-10
+
       - name: Build
         run: |
           mkdir build && cd build
-          cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=g++ -DCODE_COVERAGE=On -DLLVM_INSTALL=/usr/local ..
+          cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=g++-10 -DCODE_COVERAGE=On -DLLVM_INSTALL=/usr/local ..
           cmake --build . --parallel
       
       - name: Run Tests

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      -name: install gcc-10
+      - name: install gcc-10
         run: |
           apt-get -y update
           apt-get install -y g++-10


### PR DESCRIPTION
Generating coverage info is really slow. GCC takes ~10
minutesto build on Github action servers wwhen coverage turned on. We
don't use the coverage info as part of PR review so just remove it from
check-pr and do codecov on the develop branch only.